### PR TITLE
Refactor user-info-vsdm2.yaml

### DIFF
--- a/src/schemas/user-info-vsdm2.yaml
+++ b/src/schemas/user-info-vsdm2.yaml
@@ -1,28 +1,29 @@
-# Schema for the user-info-vsdm2 json object.
-# The VSDM2 Resource Server uses the schema to validate the ZETA-user-info HTTP header
+# user-info-vsdm2.yaml
+# Schema for the extended user-info json object (VSDM2).
+# This schema inherits from user-info.yaml and adds new attributes.
+# The VSDM2 Resource Server uses the schema to validate the ZETA-user-info HTTP header.
 #
 $schema: "http://json-schema.org/draft-07/schema#"
-user_info:
-  type: object
-  properties:
-    subject:
-      type: string
-      description: "User id. Assigned by the Authorization Server."
-    identifier:
-      type: string
-      description: "Telematik-ID, KVNR or other unique identifier"
-    professionOID:
-      type: string
-      description: "Profession identifier (OID)"
-    organizationName:
-      type: string
-      description: "Name of the organization"
-    commonName:
-      type: string
-      description: "Common name of the organization"
-  required:
-    - subject
-    - identifier
-    - professionOID
-  additionalProperties: true
- 
+
+type: object
+allOf:
+  # 1. Referenz auf das Basis-Schema
+  #    Stellt sicher, dass alle Eigenschaften und Anforderungen von user-info.yaml erfüllt sind.
+  #    Der Pfad "#/user_info" zeigt auf den "user_info" Schlüssel in der user-info.yaml Datei.
+  #    Stellen Sie sicher, dass der Pfad zur user-info.yaml korrekt ist (hier angenommen im selben Verzeichnis).
+  - $ref: "https://raw.githubusercontent.com/gematik/spec-t20r/refs/heads/main/src/schemas/user-info.yaml#/user_info"
+
+  # 2. Zusätzliche Eigenschaften und Anforderungen für user-info-vsdm2
+  - type: object
+    properties:
+      organizationName:
+        type: string
+        description: "Name of the organization"
+      commonName:
+        type: string
+        description: "Common name of the organization"
+    required:
+      # Nur die *zusätzlich* erforderlichen Felder werden hier aufgelistet.
+      # Die 'required' Felder aus dem Basis-Schema (subject, identifier, professionOID)
+      # werden durch die $ref-Referenz oben bereits implizit gefordert.
+      - commonName


### PR DESCRIPTION
This pull request updates the `user-info-vsdm2.yaml` schema to extend its functionality by referencing a base schema and adding new attributes. The changes aim to ensure better modularity and maintainability of the schema.

### Schema enhancements:

* Updated `user-info-vsdm2.yaml` to inherit from the base schema `user-info.yaml` using an `$ref` reference, ensuring all properties and requirements from the base schema are included.
* Added a new `allOf` structure to combine the base schema with additional properties specific to `user-info-vsdm2`, such as `organizationName` and `commonName`.
* Removed duplicate properties (`subject`, `identifier`, `professionOID`) and their descriptions, as they are now inherited from the base schema.
* Updated the `required` field to include only the additional required attributes (`commonName`), as the base schema's required fields are implicitly enforced.