### PR TITLE
Feature/ti patient

### DIFF
--- a/src/fhir/fsh-generated/data/fsh-index.json
+++ b/src/fhir/fsh-generated/data/fsh-index.json
@@ -68,8 +68,8 @@
     "fshName": "VSDMPatientSample",
     "fshType": "Instance",
     "fshFile": "profiles/VSDMPatient.fsh",
-    "startLine": 36,
-    "endLine": 59
+    "startLine": 37,
+    "endLine": 60
   },
   {
     "outputFile": "Patient-Valid-437f2555-2396-4c64-a656-e9553161ca3c.json",
@@ -157,7 +157,7 @@
     "fshType": "Profile",
     "fshFile": "profiles/VSDMPatient.fsh",
     "startLine": 1,
-    "endLine": 26
+    "endLine": 27
   },
   {
     "outputFile": "StructureDefinition-vsdm-wahltarife-ex.json",

--- a/src/fhir/fsh-generated/fsh-index.txt
+++ b/src/fhir/fsh-generated/fsh-index.txt
@@ -7,7 +7,7 @@ CodeSystem-vsdmkostentraeger-angabestatus-cs.json           VSDMKostentraegerAng
 Coverage-2d4da53a-413a-48fe-b908-2e67b5761523.json          VSDMCoverageSample               Instance    examples/ExampleVSDMCoverage.fsh                 2 - 9
 Coverage-VALID-413a-48fe-b908-2e67b5761523.json             VALID-VSDMCoverageSample         Instance    examples/ExampleVSDMCoverage.fsh                 13 - 19
 OperationOutcome-example-vsdm-operationoutcome.json         ExampleOperationOutcome          Instance    examples/ExampleOperationOutcome.fsh             1 - 15
-Patient-437f2555-2396-4c64-a656-e9553161ca3c.json           VSDMPatientSample                Instance    profiles/VSDMPatient.fsh                         36 - 59
+Patient-437f2555-2396-4c64-a656-e9553161ca3c.json           VSDMPatientSample                Instance    profiles/VSDMPatient.fsh                         37 - 60
 Patient-Valid-437f2555-2396-4c64-a656-e9553161ca3c.json     ValidExampleVSDMPatient          Instance    examples/ExampleVSDMPatient.fsh                  1 - 30
 StructureDefinition-VSDDatensatz.json                       VSDDatensatz                     Logical     logicalmodel/logical_VSD_Datensatz.fsh           1 - 303
 StructureDefinition-vsdm-bundle.json                        VSDMBundle                       Profile     profiles/VSDMBundle.fsh                          1 - 31
@@ -18,7 +18,7 @@ StructureDefinition-vsdm-dmp-kennzeichen-basis-ex.json      VSDMDMPKennzeichenBa
 StructureDefinition-vsdm-dmpKennzeichen-ex.json             VSDMDMPKennzeichenEX             Extension   extensions/VSDMDMPKennzeichen.fsh                1 - 25
 StructureDefinition-vsdm-kostentraeger-laendercode-ex.json  VSDMKostentraegerLaendercodeEX   Extension   extensions/VSDMKostentraegerLaendercodeEX.fsh    1 - 15
 StructureDefinition-vsdm-operationoutcome.json              VSDMOperationOutcome             Profile     profiles/VSDMOperationOutcome.fsh                1 - 34
-StructureDefinition-vsdm-patient.json                       VSDMPatient                      Profile     profiles/VSDMPatient.fsh                         1 - 26
+StructureDefinition-vsdm-patient.json                       VSDMPatient                      Profile     profiles/VSDMPatient.fsh                         1 - 27
 StructureDefinition-vsdm-wahltarife-ex.json                 VSDMWahltarifeEX                 Extension   extensions/VSDMWahltarifeEX.fsh                  1 - 36
 StructureDefinition-vsdmkostentraeger-angabestatus-ex.json  VSDMKostentraegerAngabestatusEX  Extension   extensions/VSDMKostentraegerAngabestatusEX.fsh   1 - 11
 ValueSet-vsdm-errorcode-vs.json                             VSDMErrorcodeVS                  ValueSet    valuesets/VSDMErrorcodeVS.fsh                    1 - 8

--- a/src/fhir/fsh-generated/resources/StructureDefinition-vsdm-patient.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-vsdm-patient.json
@@ -8,10 +8,37 @@
   "date": "2023-12-31",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "cda",
+      "uri": "http://hl7.org/v3/cda",
+      "name": "CDA (R2)"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    },
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "loinc",
+      "uri": "http://loinc.org",
+      "name": "LOINC code for the element"
+    }
+  ],
   "kind": "resource",
   "abstract": false,
   "type": "Patient",
-  "baseDefinition": "https://gematik.de/fhir/epa/StructureDefinition/epa-patient",
+  "baseDefinition": "https://gematik.de/fhir/ti/StructureDefinition/ti-patient",
   "derivation": "constraint",
   "snapshot": {
     "element": [
@@ -86,7 +113,7 @@
             "severity": "error",
             "human": "Die amtliche Differenzierung der Geschlechtsangabe 'other' darf nur gefüllt sein, wenn das Geschlecht 'other' angegeben ist",
             "expression": "gender.exists() and gender='other' implies gender.extension('http://fhir.de/StructureDefinition/gender-amtlich-de').exists()",
-            "source": "https://gematik.de/fhir/epa/StructureDefinition/epa-patient"
+            "source": "https://gematik.de/fhir/ti/StructureDefinition/ti-patient"
           }
         ],
         "isModifier": false,
@@ -125,7 +152,7 @@
             "extension": [
               {
                 "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-                "valueUrl": "string"
+                "valueUrl": "id"
               }
             ]
           }
@@ -296,7 +323,7 @@
         "path": "Patient.meta.lastUpdated",
         "short": "When the resource version last changed",
         "definition": "When the resource last changed - e.g. when the version changed.",
-        "comment": "This value is always populated except when the resource is first being created. The server / resource manager sets this value; what a client provides is irrelevant. This is equivalent to the HTTP Last-Modified and SHOULD have the same value on a [read](http.html#read) interaction.",
+        "comment": "This value is always populated except when the resource is first being created. The server / resource manager sets this value; what a client provides is irrelevant. This is equivalent to the HTTP Last-Modified and SHOULD have the same value on a [read](http://hl7.org/fhir/R4/http.html#read) interaction.",
         "min": 0,
         "max": "1",
         "base": {
@@ -327,7 +354,7 @@
         "id": "Patient.meta.source",
         "path": "Patient.meta.source",
         "short": "Identifies where the resource comes from",
-        "definition": "A uri that identifies the source system of the resource. This provides a minimal amount of [Provenance](provenance.html#) information that can be used to track or differentiate the source of information in the resource. The source may identify another FHIR server, document, message, database, etc.",
+        "definition": "A uri that identifies the source system of the resource. This provides a minimal amount of [Provenance](http://hl7.org/fhir/R4/provenance.html#) information that can be used to track or differentiate the source of information in the resource. The source may identify another FHIR server, document, message, database, etc.",
         "comment": "In the provenance resource, this corresponds to Provenance.entity.what[x]. The exact use of the source (and the implied Provenance.entity.role) is left to implementer discretion. Only one nominated source is allowed; for additional provenance details, a full Provenance resource should be used. \n\nThis element can be used to indicate where the current master source of a resource that has a canonical URL if the resource is no longer hosted at the canonical URL.",
         "min": 0,
         "max": "1",
@@ -358,7 +385,7 @@
         "id": "Patient.meta.profile",
         "path": "Patient.meta.profile",
         "short": "Profiles this resource claims to conform to",
-        "definition": "A list of profiles (references to [StructureDefinition](structuredefinition.html#) resources) that this resource claims to conform to. The URL is a reference to [StructureDefinition.url](structuredefinition-definitions.html#StructureDefinition.url).",
+        "definition": "A list of profiles (references to [StructureDefinition](http://hl7.org/fhir/R4/structuredefinition.html#) resources) that this resource claims to conform to. The URL is a reference to [StructureDefinition.url](http://hl7.org/fhir/R4/structuredefinition-definitions.html#StructureDefinition.url).",
         "comment": "It is up to the server and/or other infrastructure of policy to determine whether/how these claims are verified and/or updated over time.  The list of profile URLs is a set.",
         "min": 1,
         "max": "1",
@@ -424,10 +451,6 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
               "valueString": "SecurityLabels"
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-              "valueBoolean": true
             }
           ],
           "strength": "extensible",
@@ -548,10 +571,6 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
               "valueString": "Language"
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-              "valueBoolean": true
             }
           ],
           "strength": "preferred",
@@ -689,7 +708,7 @@
         "short": "Extensions that cannot be ignored",
         "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
         "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension).",
+        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
         "alias": [
           "extensions",
           "user content"
@@ -750,7 +769,7 @@
         "definition": "An identifier for this patient.",
         "requirements": "Patients are almost always assigned specific numerical identifiers.",
         "min": 1,
-        "max": "1",
+        "max": "*",
         "base": {
           "path": "Patient.identifier",
           "min": 0,
@@ -795,20 +814,10 @@
       },
       {
         "id": "Patient.identifier:KVNR",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-            "valueCode": "normative"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
-          }
-        ],
         "path": "Patient.identifier",
         "sliceName": "KVNR",
-        "short": "An identifier intended for computation",
-        "definition": "An identifier - identifies some entity uniquely and unambiguously. Typically this is used for business identifiers.",
+        "short": "An identifier for this patient",
+        "definition": "An identifier for this patient.",
         "requirements": "Patients are almost always assigned specific numerical identifiers.",
         "min": 1,
         "max": "1",
@@ -824,9 +833,6 @@
               "http://fhir.de/StructureDefinition/identifier-kvid-10"
             ]
           }
-        ],
-        "condition": [
-          "ele-1"
         ],
         "constraint": [
           {
@@ -857,22 +863,6 @@
           {
             "identity": "cda",
             "map": ".id"
-          },
-          {
-            "identity": "rim",
-            "map": "n/a"
-          },
-          {
-            "identity": "v2",
-            "map": "CX / EI (occasionally, more often EI maps to a resource id or a URL)"
-          },
-          {
-            "identity": "rim",
-            "map": "II - The Identifier class is a little looser than the v3 type II because it allows URIs as well as registered OIDs or GUIDs.  Also maps to Role[classCode=IDENT]"
-          },
-          {
-            "identity": "servd",
-            "map": "Identifier"
           }
         ]
       },
@@ -931,7 +921,7 @@
         "slicing": {
           "discriminator": [
             {
-              "type": "pattern",
+              "type": "value",
               "path": "$this"
             }
           ],
@@ -939,7 +929,7 @@
         },
         "short": "A name associated with the patient",
         "definition": "A name associated with the individual.",
-        "comment": "In order to maintain the differentiations of name parts as given in the VSDM dataset or qualify prefixes as academic titles, vendors can opt to support the extensions specified in the German HumanName Base Profile https://simplifier.net/basisprofil-de-r4/humannamedebasis\r\nThis is however not required within the scope of this specification.",
+        "comment": "Um die Unterscheidung der Namensbestandteile gemäß dem VSDM-Datensatz beizubehalten oder Präfixe als akademische Titel zu qualifizieren, können Anbieter die im deutschen HumanName-Basisprofil spezifizierten Erweiterungen unterstützen: HumanName DE Basis (https://simplifier.net/basisprofil-de-r4/humannamedebasis).\n\nDies ist jedoch nicht verpflichtend im Rahmen dieser Spezifikation.",
         "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
         "min": 1,
         "max": "*",
@@ -983,21 +973,11 @@
       },
       {
         "id": "Patient.name:Name",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-            "valueCode": "normative"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
-          }
-        ],
         "path": "Patient.name",
         "sliceName": "Name",
-        "short": "Personenname",
-        "definition": "Personenname mit in Deutschland üblichen Erweiterungen",
-        "comment": "Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely.",
+        "short": "A name associated with the patient",
+        "definition": "A name associated with the individual.",
+        "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
         "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
         "min": 1,
         "max": "1",
@@ -1017,9 +997,6 @@
         "patternHumanName": {
           "use": "official"
         },
-        "condition": [
-          "ele-1"
-        ],
         "constraint": [
           {
             "key": "ele-1",
@@ -1028,34 +1005,6 @@
             "expression": "hasValue() or (children().count() > id.count())",
             "xpath": "@value|f:*|h:div",
             "source": "http://hl7.org/fhir/StructureDefinition/Element"
-          },
-          {
-            "key": "hum-1",
-            "severity": "error",
-            "human": "Wenn die Extension 'namenszusatz' verwendet wird, dann muss der vollständige Name im Attribut 'family' angegeben werden",
-            "expression": "family.extension('http://fhir.de/StructureDefinition/humanname-namenszusatz').empty() or family.hasValue()",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
-          },
-          {
-            "key": "hum-2",
-            "severity": "error",
-            "human": "Wenn die Extension 'nachname' verwendet wird, dann muss der vollständige Name im Attribut 'family' angegeben werden",
-            "expression": "family.extension('http://hl7.org/fhir/StructureDefinition/humanname-own-name').empty() or family.hasValue()",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
-          },
-          {
-            "key": "hum-3",
-            "severity": "error",
-            "human": "Wenn die Extension 'vorsatzwort' verwendet wird, dann muss der vollständige Name im Attribut 'family' angegeben werden",
-            "expression": "family.extension('http://hl7.org/fhir/StructureDefinition/humanname-own-prefix').empty() or family.hasValue()",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
-          },
-          {
-            "key": "hum-4",
-            "severity": "error",
-            "human": "Wenn die Extension 'prefix-qualifier' verwendet wird, dann muss ein Namenspräfix im Attribut 'prefix' angegeben werden",
-            "expression": "prefix.all($this.extension('http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier').empty() or $this.hasValue())",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
           }
         ],
         "mustSupport": true,
@@ -1073,22 +1022,6 @@
           {
             "identity": "cda",
             "map": ".patient.name"
-          },
-          {
-            "identity": "rim",
-            "map": "n/a"
-          },
-          {
-            "identity": "v2",
-            "map": "XPN"
-          },
-          {
-            "identity": "rim",
-            "map": "EN (actually, PN)"
-          },
-          {
-            "identity": "servd",
-            "map": "ProviderName"
           }
         ]
       },
@@ -1420,25 +1353,11 @@
       },
       {
         "id": "Patient.name:Name.family.extension:namenszusatz",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-            "valueCode": "normative"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
-          }
-        ],
         "path": "Patient.name.family.extension",
         "sliceName": "namenszusatz",
         "short": "Namenszusatz gemäß VSDM (Versichertenstammdatenmanagement, \"eGK\")",
         "definition": "Namenszusatz als Bestandteil das Nachnamens, wie in VSDM (Versichertenstammdatenmanagement, \"eGK\") definiert.\r\nBeispiele: Gräfin, Prinz oder Fürst",
         "comment": "Die Extension wurde erstellt aufgrund der Anforderung, die auf der eGK vorhandenen Patientenstammdaten in FHIR abbilden zu können. Auf der eGK werden die Namensbestandteile \"Namenszusatz\" und \"Vorsatzwort\" getrennt vom Nachnamen gespeichert. Anhand der Liste der zulässigen Namenszusätze ist deutlich erkennbar, dass es sich hierbei sinngemäß um Adelstitel handelt.\r\nDas Vorsatzwort kann durch die Core-Extension own-prefix\t(Canonical: http://hl7.org/fhir/StructureDefinition/humanname-own-prefix) abgebildet werden, für den Namenszusatz ergibt sich jedoch die Notwendikeit einer nationalen Extension, da in andern Ländern Adelstitel entweder gar nicht oder als reguläres Namenspräfix erfasst werden.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -1493,13 +1412,9 @@
         "id": "Patient.name:Name.family.extension:nachname",
         "path": "Patient.name.family.extension",
         "sliceName": "nachname",
-        "short": "Nachname ohne Vor- und Zusätze",
-        "definition": "Nachname ohne Vor- und Zusätze.\r\nDient z.B. der alphabetischen Einordnung des Namens.",
+        "short": "Portion derived from person's own surname",
+        "definition": "The portion of the family name that is derived from the person's own surname, as distinguished from any portion that is derived from the surname of the person's partner or spouse.",
         "comment": "Gibt den Nachnamen der Person an",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -1554,13 +1469,9 @@
         "id": "Patient.name:Name.family.extension:vorsatzwort",
         "path": "Patient.name.family.extension",
         "sliceName": "vorsatzwort",
-        "short": "Vorsatzwort",
-        "definition": "Vorsatzwort wie z.B.: von, van, zu\r\nVgl. auch VSDM-Spezifikation der Gematik (Versichertenstammdatenmanagement, \"eGK\")",
+        "short": "Voorvoegsel derived from person's own surname",
+        "definition": "The prefix portion (e.g. voorvoegsel) of the family name that is derived from the person's own surname, as distinguished from any portion that is derived from the surname of the person's partner or spouse.",
         "comment": "An example of a voorvoegsel is the \"van\" in \"Ludwig van Beethoven\". Since the voorvoegsel doesn't sort completely alphabetically, it is reasonable to specify it as a separate sub-component.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -1829,12 +1740,8 @@
         "path": "Patient.name.prefix.extension",
         "sliceName": "prefix-qualifier",
         "short": "LS | AC | NB | PR | HON | BR | AD | SP | MID | CL | IN | VV",
-        "definition": "Spezialisierung der Art des Präfixes, z.B. \"AC\" für Akademische Titel",
+        "definition": "A set of codes each of which specifies a certain subcategory of the name part in addition to the main name part type.",
         "comment": "Used to indicate additional information about the name part and how it should be used.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -1902,10 +1809,13 @@
             "extension": [
               {
                 "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-                "valueUrl": "string"
+                "valueUrl": "id"
               }
             ]
           }
+        ],
+        "condition": [
+          "ele-1"
         ],
         "isModifier": false,
         "isSummary": false,
@@ -1949,7 +1859,6 @@
             "severity": "error",
             "human": "All FHIR elements must have a @value or children",
             "expression": "hasValue() or (children().count() > id.count())",
-            "xpath": "@value|f:*|h:div",
             "source": "http://hl7.org/fhir/StructureDefinition/Element"
           },
           {
@@ -1957,7 +1866,6 @@
             "severity": "error",
             "human": "Must have either extensions or value[x], not both",
             "expression": "extension.exists() != value.exists()",
-            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
             "source": "http://hl7.org/fhir/StructureDefinition/Extension"
           }
         ],
@@ -2005,7 +1913,7 @@
         "id": "Patient.name:Name.prefix.extension:prefix-qualifier.value[x]",
         "path": "Patient.name.prefix.extension.value[x]",
         "short": "Value of extension",
-        "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/extensibility.html) for a list).",
+        "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R5/extensibility.html) for a list).",
         "min": 1,
         "max": "1",
         "base": {
@@ -2019,13 +1927,15 @@
           }
         ],
         "fixedCode": "AC",
+        "condition": [
+          "ext-1"
+        ],
         "constraint": [
           {
             "key": "ele-1",
             "severity": "error",
             "human": "All FHIR elements must have a @value or children",
             "expression": "hasValue() or (children().count() > id.count())",
-            "xpath": "@value|f:*|h:div",
             "source": "http://hl7.org/fhir/StructureDefinition/Element"
           }
         ],
@@ -2039,8 +1949,7 @@
             }
           ],
           "strength": "required",
-          "description": "A set of codes each of which specifies a certain subcategory of the name part in addition to the main name part type.",
-          "valueSet": "http://hl7.org/fhir/ValueSet/name-part-qualifier|4.0.1"
+          "valueSet": "http://hl7.org/fhir/ValueSet/name-part-qualifier"
         },
         "mapping": [
           {
@@ -2171,21 +2080,11 @@
       },
       {
         "id": "Patient.name:Geburtsname",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-            "valueCode": "normative"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
-          }
-        ],
         "path": "Patient.name",
         "sliceName": "Geburtsname",
-        "short": "Personenname",
-        "definition": "Personenname mit in Deutschland üblichen Erweiterungen",
-        "comment": "Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts may or may not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely.",
+        "short": "A name associated with the patient",
+        "definition": "A name associated with the individual.",
+        "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
         "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
         "min": 0,
         "max": "1",
@@ -2205,9 +2104,6 @@
         "patternHumanName": {
           "use": "maiden"
         },
-        "condition": [
-          "ele-1"
-        ],
         "constraint": [
           {
             "key": "ele-1",
@@ -2216,34 +2112,6 @@
             "expression": "hasValue() or (children().count() > id.count())",
             "xpath": "@value|f:*|h:div",
             "source": "http://hl7.org/fhir/StructureDefinition/Element"
-          },
-          {
-            "key": "hum-1",
-            "severity": "error",
-            "human": "Wenn die Extension 'namenszusatz' verwendet wird, dann muss der vollständige Name im Attribut 'family' angegeben werden",
-            "expression": "family.extension('http://fhir.de/StructureDefinition/humanname-namenszusatz').empty() or family.hasValue()",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
-          },
-          {
-            "key": "hum-2",
-            "severity": "error",
-            "human": "Wenn die Extension 'nachname' verwendet wird, dann muss der vollständige Name im Attribut 'family' angegeben werden",
-            "expression": "family.extension('http://hl7.org/fhir/StructureDefinition/humanname-own-name').empty() or family.hasValue()",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
-          },
-          {
-            "key": "hum-3",
-            "severity": "error",
-            "human": "Wenn die Extension 'vorsatzwort' verwendet wird, dann muss der vollständige Name im Attribut 'family' angegeben werden",
-            "expression": "family.extension('http://hl7.org/fhir/StructureDefinition/humanname-own-prefix').empty() or family.hasValue()",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
-          },
-          {
-            "key": "hum-4",
-            "severity": "error",
-            "human": "Wenn die Extension 'prefix-qualifier' verwendet wird, dann muss ein Namenspräfix im Attribut 'prefix' angegeben werden",
-            "expression": "prefix.all($this.extension('http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier').empty() or $this.hasValue())",
-            "source": "http://fhir.de/StructureDefinition/humanname-de-basis"
           }
         ],
         "mustSupport": true,
@@ -2261,22 +2129,6 @@
           {
             "identity": "cda",
             "map": ".patient.name"
-          },
-          {
-            "identity": "rim",
-            "map": "n/a"
-          },
-          {
-            "identity": "v2",
-            "map": "XPN"
-          },
-          {
-            "identity": "rim",
-            "map": "EN (actually, PN)"
-          },
-          {
-            "identity": "servd",
-            "map": "ProviderName"
           }
         ]
       },
@@ -2608,25 +2460,11 @@
       },
       {
         "id": "Patient.name:Geburtsname.family.extension:namenszusatz",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-            "valueCode": "normative"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
-          }
-        ],
         "path": "Patient.name.family.extension",
         "sliceName": "namenszusatz",
         "short": "Namenszusatz gemäß VSDM (Versichertenstammdatenmanagement, \"eGK\")",
         "definition": "Namenszusatz als Bestandteil das Nachnamens, wie in VSDM (Versichertenstammdatenmanagement, \"eGK\") definiert.\r\nBeispiele: Gräfin, Prinz oder Fürst",
         "comment": "Die Extension wurde erstellt aufgrund der Anforderung, die auf der eGK vorhandenen Patientenstammdaten in FHIR abbilden zu können. Auf der eGK werden die Namensbestandteile \"Namenszusatz\" und \"Vorsatzwort\" getrennt vom Nachnamen gespeichert. Anhand der Liste der zulässigen Namenszusätze ist deutlich erkennbar, dass es sich hierbei sinngemäß um Adelstitel handelt.\r\nDas Vorsatzwort kann durch die Core-Extension own-prefix\t(Canonical: http://hl7.org/fhir/StructureDefinition/humanname-own-prefix) abgebildet werden, für den Namenszusatz ergibt sich jedoch die Notwendikeit einer nationalen Extension, da in andern Ländern Adelstitel entweder gar nicht oder als reguläres Namenspräfix erfasst werden.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -2681,13 +2519,9 @@
         "id": "Patient.name:Geburtsname.family.extension:nachname",
         "path": "Patient.name.family.extension",
         "sliceName": "nachname",
-        "short": "Nachname ohne Vor- und Zusätze",
-        "definition": "Nachname ohne Vor- und Zusätze.\r\nDient z.B. der alphabetischen Einordnung des Namens.",
+        "short": "Portion derived from person's own surname",
+        "definition": "The portion of the family name that is derived from the person's own surname, as distinguished from any portion that is derived from the surname of the person's partner or spouse.",
         "comment": "If the person's surname has legally changed to become (or incorporate) the surname of the person's partner or spouse, this is the person's surname immediately prior to such change. Often this is the person's \"maiden name\".",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -2742,13 +2576,9 @@
         "id": "Patient.name:Geburtsname.family.extension:vorsatzwort",
         "path": "Patient.name.family.extension",
         "sliceName": "vorsatzwort",
-        "short": "Vorsatzwort",
-        "definition": "Vorsatzwort wie z.B.: von, van, zu\r\nVgl. auch VSDM-Spezifikation der Gematik (Versichertenstammdatenmanagement, \"eGK\")",
+        "short": "Voorvoegsel derived from person's own surname",
+        "definition": "The prefix portion (e.g. voorvoegsel) of the family name that is derived from the person's own surname, as distinguished from any portion that is derived from the surname of the person's partner or spouse.",
         "comment": "An example of a voorvoegsel is the \"van\" in \"Ludwig van Beethoven\". Since the voorvoegsel doesn't sort completely alphabetically, it is reasonable to specify it as a separate sub-component.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -3331,10 +3161,6 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
               "valueString": "AdministrativeGender"
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-              "valueBoolean": true
             }
           ],
           "strength": "required",
@@ -3398,13 +3224,8 @@
           "ordered": false,
           "rules": "open"
         },
-        "short": "Additional content defined by implementations",
-        "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
+        "short": "Extension",
+        "definition": "An Extension",
         "min": 0,
         "max": "*",
         "base": {
@@ -3440,25 +3261,10 @@
       },
       {
         "id": "Patient.gender.extension:other-amtlich",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-            "valueCode": "normative"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
-          }
-        ],
         "path": "Patient.gender.extension",
         "sliceName": "other-amtlich",
         "short": "Optional Extensions Element",
         "definition": "Optional Extension Element - found in all resources.",
-        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-        "alias": [
-          "extensions",
-          "user content"
-        ],
         "min": 0,
         "max": "1",
         "base": {
@@ -3492,7 +3298,7 @@
             "human": "Must have either extensions or value[x], not both",
             "expression": "extension.exists() != value.exists()",
             "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+            "source": "http://hl7.org/fhir/StructureDefinition/Patient"
           }
         ],
         "isModifier": false,
@@ -3726,10 +3532,6 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
               "valueString": "MaritalStatus"
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-              "valueBoolean": true
             }
           ],
           "strength": "extensible",
@@ -3848,12 +3650,6 @@
       },
       {
         "id": "Patient.contact",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-            "valueString": "Contact"
-          }
-        ],
         "path": "Patient.contact",
         "short": "A contact party (e.g. guardian, partner, friend) for the patient",
         "definition": "A contact party (e.g. guardian, partner, friend) for the patient.",
@@ -3885,7 +3681,8 @@
             "severity": "error",
             "human": "SHALL at least contain a contact's details or a reference to an organization",
             "expression": "name.exists() or telecom.exists() or address.exists() or organization.exists()",
-            "xpath": "exists(f:name) or exists(f:telecom) or exists(f:address) or exists(f:organization)"
+            "xpath": "exists(f:name) or exists(f:telecom) or exists(f:address) or exists(f:organization)",
+            "source": "http://hl7.org/fhir/StructureDefinition/Patient"
           }
         ],
         "isModifier": false,
@@ -3991,7 +3788,7 @@
         "short": "Extensions that cannot be ignored even if unrecognized",
         "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
         "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension).",
+        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
         "alias": [
           "extensions",
           "user content",
@@ -4264,10 +4061,6 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
               "valueString": "AdministrativeGender"
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-              "valueBoolean": true
             }
           ],
           "strength": "required",
@@ -4512,7 +4305,7 @@
         "short": "Extensions that cannot be ignored even if unrecognized",
         "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
         "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension).",
+        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
         "alias": [
           "extensions",
           "user content",
@@ -4598,10 +4391,6 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
               "valueString": "Language"
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-              "valueBoolean": true
             }
           ],
           "strength": "preferred",
@@ -4900,7 +4689,7 @@
         "short": "Extensions that cannot be ignored even if unrecognized",
         "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
         "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension).",
+        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
         "alias": [
           "extensions",
           "user content",
@@ -5071,7 +4860,13 @@
       {
         "id": "Patient.identifier",
         "path": "Patient.identifier",
-        "max": "1"
+        "min": 1
+      },
+      {
+        "id": "Patient.identifier:KVNR",
+        "path": "Patient.identifier",
+        "sliceName": "KVNR",
+        "min": 1
       },
       {
         "id": "Patient.name:Name",

--- a/src/fhir/input/fsh/profiles/VSDMPatient.fsh
+++ b/src/fhir/input/fsh/profiles/VSDMPatient.fsh
@@ -1,12 +1,13 @@
 Profile: VSDMPatient
-Parent: EPAPatient
+Parent: TIPatient
 Id: vsdm-patient
 * ^url = "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient"
 * insert Meta
 * meta 1..1
 * meta.profile 1..1
 * meta.profile = "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient" (exactly)
-* identifier 1..1
+
+* identifier[KVNR] 1..1
 
 * address only address-de-basis
 

--- a/src/fhir/sushi-config.yaml
+++ b/src/fhir/sushi-config.yaml
@@ -12,5 +12,5 @@ applyExtensionMetadataToRoot: false
 #  email: info@gematik.de
 dependencies:
   hl7.fhir.r4.core: 4.0.1
-  de.basisprofil.r4: 1.5.0
-  de.gematik.epa: 1.1.0
+  de.basisprofil.r4: 1.5.3
+  de.gematik.ti: 1.1.0


### PR DESCRIPTION
Mit diesem PR wird der EPAPatient durch den TIPatient ersetzt. Dazu wird die Paketabhängigkeit von de.gematik.epa ersetzt durch de.gematik.ti. In diesem Zuge wurde die Version der Abhängigkeit zu de.basisprofil.r4 angehoben, damit sie konsistent zu de.gematik.ti ist.

Bei dem Austausch sind deutlich mehr Änderungen im VSDMPatient als ursprünglich erwartet entstanden, so dass die Änderung gründlich geprüft werden muss.