### PR TITLE
expression durch location ersetzt

### DIFF
--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidIK.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidIK.json
@@ -25,7 +25,7 @@
         "text": "Ungültige oder nicht bekannte Institutionskennung 103456789."
       },
       "diagnostics": "Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. \nBei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem oder PoPP-Service) oder der Kostenträger nicht von diesem Farchdienst-Anbieter vertreten wird (fehlerhafter DNS-Eintrag).",
-      "expression": [
+      "location": [
         "http.ZETA-PoPP-Token-Content.insurerId"
       ]
     }

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidKVNR.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidKVNR.json
@@ -25,7 +25,7 @@
         "text": "Ungültige oder nicht bekannte Krankenversichertennummer 1234567890."
       },
       "diagnostics": "Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. \nBei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem oder PoPP-Service).",
-      "expression": [
+      "location": [
         "http.ZETA-PoPP-Token-Content.patientId"
       ]
     }

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidPatientRecordVersion.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidPatientRecordVersion.json
@@ -25,7 +25,7 @@
         "text": "Der Änderungsindikator 0xdeadbeef kann nicht verarbeitet werden."
       },
       "diagnostics": "Implementierungsfehler beim Clientsystem - der Hersteller des Clientsystems ist zu kontaktieren.",
-      "expression": [
+      "location": [
         "http.If-None-Match"
       ]
     }

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-MissingOrInvalidHeader.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-MissingOrInvalidHeader.json
@@ -25,7 +25,7 @@
         "text": "Der erforderliche HTTP-Header ZETA-PoPP-Token fehlt oder ist undgültig."
       },
       "diagnostics": "Im Falle des Headers PoPP: Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. \nBei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem).",
-      "expression": [
+      "location": [
         "http.ZETA-PoPP-Token"
       ]
     }

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-PatientRecordNotFound.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-PatientRecordNotFound.json
@@ -25,7 +25,7 @@
         "text": "Die Versichertenstammdaten zur Versichertennummer 1234567890 konnten für die Institutionskennung 103456789 nicht ermittelt werden."
       },
       "diagnostics": "Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. \nBei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem, PoPP-Service oder Schnittstelle zu KTR-Bestandssystemen).",
-      "expression": [
+      "location": [
         "http.ZETA-PoPP-Token-Content.insurerId",
         "http.ZETA-PoPP-Token-Content.patientId"
       ]

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnsupportedEncoding.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnsupportedEncoding.json
@@ -25,7 +25,7 @@
         "text": "Das vom Clientsystem angefragte Komprimierungsverfahren implode wird nicht unterstützt."
       },
       "diagnostics": "Implementierungsfehler beim Clientsystem - der Hersteller des Clientsystems ist zu kontaktieren.",
-      "expression": [
+      "location": [
         "http.Content-Encoding"
       ]
     }

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnsupportedMediatype.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnsupportedMediatype.json
@@ -25,7 +25,7 @@
         "text": "Der vom Clientsystem angefragte Medientyp application/morse-code wird nicht unterstützt."
       },
       "diagnostics": "Implementierungsfehler beim Clientsystem - der Hersteller des Clientsystems ist zu kontaktieren.",
-      "expression": [
+      "location": [
         "http.Accept"
       ]
     }

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidIK.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidIK.fsh
@@ -21,4 +21,4 @@ Usage: #example
       Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. 
       Bei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem oder PoPP-Service) oder der Kostenträger nicht von diesem Farchdienst-Anbieter vertreten wird (fehlerhafter DNS-Eintrag).
     """
-  * expression[+] = "http.ZETA-PoPP-Token-Content.insurerId"
+  * location[+] = "http.ZETA-PoPP-Token-Content.insurerId"

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidKVNR.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidKVNR.fsh
@@ -21,4 +21,4 @@ Usage: #example
       Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. 
       Bei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem oder PoPP-Service).
     """
-  * expression[+] = "http.ZETA-PoPP-Token-Content.patientId"
+  * location[+] = "http.ZETA-PoPP-Token-Content.patientId"

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidPatientRecordVersion.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidPatientRecordVersion.fsh
@@ -20,4 +20,4 @@ Usage: #example
   * diagnostics = """
       Implementierungsfehler beim Clientsystem - der Hersteller des Clientsystems ist zu kontaktieren.
     """
-  * expression[+] = "http.If-None-Match"
+  * location[+] = "http.If-None-Match"

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-MissingOrInvalidHeader.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-MissingOrInvalidHeader.fsh
@@ -21,4 +21,4 @@ Usage: #example
       Im Falle des Headers PoPP: Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. 
       Bei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem).
     """
-  * expression[+] = "http.ZETA-PoPP-Token"
+  * location[+] = "http.ZETA-PoPP-Token"

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-PatientRecordNotFound.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-PatientRecordNotFound.fsh
@@ -21,5 +21,5 @@ Usage: #example
       Nachweis zum Versorgungskontext mittels eGK oder GesundheitsID am PoPP-Service 1x erneuern. 
       Bei erneutem Fehler: Abbruch, da wahrscheinlich ein Implementierungsfehler vorliegt (Clientsystem, PoPP-Service oder Schnittstelle zu KTR-Bestandssystemen).
     """
-  * expression[+] = "http.ZETA-PoPP-Token-Content.insurerId"
-  * expression[+] = "http.ZETA-PoPP-Token-Content.patientId"
+  * location[+] = "http.ZETA-PoPP-Token-Content.insurerId"
+  * location[+] = "http.ZETA-PoPP-Token-Content.patientId"

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnsupportedEncoding.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnsupportedEncoding.fsh
@@ -20,4 +20,4 @@ Usage: #example
   * diagnostics = """
       Implementierungsfehler beim Clientsystem - der Hersteller des Clientsystems ist zu kontaktieren.
     """
-  * expression[+] = "http.Content-Encoding"
+  * location[+] = "http.Content-Encoding"

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnsupportedMediatype.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnsupportedMediatype.fsh
@@ -20,4 +20,4 @@ Usage: #example
   * diagnostics = """
       Implementierungsfehler beim Clientsystem - der Hersteller des Clientsystems ist zu kontaktieren.
     """
-  * expression[+] = "http.Accept"
+  * location[+] = "http.Accept"


### PR DESCRIPTION
Dieser PR korrigiert die fehlerhaften Beispiele (expression statt location). Fixes #61 