### PR TITLE
Ausschluss der veralteten WOP-Werte aus ValueSet

### DIFF
--- a/src/fhir/fsh-generated/data/fsh-index.json
+++ b/src/fhir/fsh-generated/data/fsh-index.json
@@ -533,6 +533,6 @@
     "fshType": "ValueSet",
     "fshFile": "valuesets/VSDMWohnortprinzipVS.fsh",
     "startLine": 1,
-    "endLine": 48
+    "endLine": 23
   }
 ]

--- a/src/fhir/fsh-generated/fsh-index.txt
+++ b/src/fhir/fsh-generated/fsh-index.txt
@@ -65,4 +65,4 @@ ValueSet-VSDMRuhenderLeistungsanspruchArtVS.json                        VSDMRuhe
 ValueSet-VSDMSozialtarifPKVVS.json                                      VSDMSozialtarifPKVVS                              ValueSet    valuesets/VSDMSozialtarifPKVVS.fsh                             1 - 7
 ValueSet-VSDMVersichertenartPKVVS.json                                  VSDMVersichertenartPKVVS                          ValueSet    valuesets/VSDMVersichertenartPKVVS.fsh                         1 - 7
 ValueSet-VSDMVorsatzwortVS.json                                         VSDMVorsatzwortVS                                 ValueSet    valuesets/VSDMVorsatzwortVS.fsh                                1 - 7
-ValueSet-VSDMWohnortprinzipVS.json                                      VSDMWohnortprinzipVS                              ValueSet    valuesets/VSDMWohnortprinzipVS.fsh                             1 - 48
+ValueSet-VSDMWohnortprinzipVS.json                                      VSDMWohnortprinzipVS                              ValueSet    valuesets/VSDMWohnortprinzipVS.fsh                             1 - 23

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMWohnortprinzipVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMWohnortprinzipVS.json
@@ -53,7 +53,7 @@
           },
           {
             "code": "71",
-            "display": "Bayerns"
+            "display": "Bayern"
           },
           {
             "code": "72",
@@ -82,42 +82,6 @@
           {
             "code": "98",
             "display": "Sachsen"
-          },
-          {
-            "code": "00",
-            "display": "WIP: Dummy bei eGK"
-          },
-          {
-            "code": "47",
-            "display": "WIP: Koblenz"
-          },
-          {
-            "code": "48",
-            "display": "WIP: Rheinhessen"
-          },
-          {
-            "code": "49",
-            "display": "WIP: Pfalz"
-          },
-          {
-            "code": "50",
-            "display": "WIP: Trier"
-          },
-          {
-            "code": "55",
-            "display": "WIP: Nordbaden"
-          },
-          {
-            "code": "60",
-            "display": "WIP: Südbaden"
-          },
-          {
-            "code": "61",
-            "display": "WIP: Nordwürttemberg"
-          },
-          {
-            "code": "62",
-            "display": "WIP: Südwürttemberg"
           }
         ]
       }

--- a/src/fhir/input/fsh/valuesets/VSDMWohnortprinzipVS.fsh
+++ b/src/fhir/input/fsh/valuesets/VSDMWohnortprinzipVS.fsh
@@ -13,7 +13,7 @@ Description: "Wohnortprinzip im Versichertenstammdatenmanagement (VSDM) 2.0"
 * include $csWOP#46 "Hessen"
 * include $csWOP#51 "Rheinland-Pfalz"
 * include $csWOP#52 "Baden-Württemberg"
-* include $csWOP#71 "Bayerns"
+* include $csWOP#71 "Bayern"
 * include $csWOP#72 "Berlin"
 * include $csWOP#73 "Saarland"
 * include $csWOP#78 "Mecklenburg-Vorpommern"
@@ -22,27 +22,18 @@ Description: "Wohnortprinzip im Versichertenstammdatenmanagement (VSDM) 2.0"
 * include $csWOP#93 "Thüringen"
 * include $csWOP#98 "Sachsen"
 
-// TODO Umfang der erlaubten Werte klären
-// Die folgenden Codes aus dem CodeSystem sind in der BMV-Ä-Vorgabetabelle nicht enthalten, 
-// aber nach Einschätzung des GKV-SV ergänzend aufzunehmen. Eine Bestätigung der KBV sollte 
-// aber vorab eingeholt werden, da der Punkt nicht Teil der KBV/GKV-SV Verhandlungen war. 
+// Die folgenden Codes aus dem Ausgangs-CodeSystem https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_ITA_WOP sind in der BMV-Ä-Vorgabetabelle nicht enthalten. 
 
-// Wenn das vollständige CodeSystem zugelassen werden soll, kann dieses ValueSet
-// entfallen und durch https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_ITA_WOP ersetzt werden.
-
-// Der folgende "Leerwert" ist für VSDM 2.0 nach aktuellem Wissensstand nicht mehr notwendig.
-
-* include $csWOP#00 "WIP: Dummy bei eGK"
+// Der folgende "Leerwert" ist für VSDM 2.0 nicht mehr notwendig.
+// * include $csWOP#00 "Dummy bei eGK"
 
 // Die folgenden Werte sind in der KVDT-Datensatzbeschreibung als "fusioniert, teilweise aber noch in Gebrauch (bspw. KVK-WOP)" markiert.
 // https://update.kbv.de/ita-update/Abrechnung/KBV_ITA_VGEX_Datensatzbeschreibung_KVDT.pdf 
-// Abstimmung Maximilian Reith 04.09.2025: Klärung der weiteren Notwendigkeit für VSDM 2.0 KBV-intern 
-
-* include $csWOP#47 "WIP: Koblenz"
-* include $csWOP#48 "WIP: Rheinhessen"
-* include $csWOP#49 "WIP: Pfalz"
-* include $csWOP#50 "WIP: Trier"
-* include $csWOP#55 "WIP: Nordbaden"
-* include $csWOP#60 "WIP: Südbaden"
-* include $csWOP#61 "WIP: Nordwürttemberg"
-* include $csWOP#62 "WIP: Südwürttemberg"
+// * include $csWOP#47 "Koblenz"
+// * include $csWOP#48 "Rheinhessen"
+// * include $csWOP#49 "Pfalz"
+// * include $csWOP#50 "Trier"
+// * include $csWOP#55 "Nordbaden"
+// * include $csWOP#60 "Südbaden"
+// * include $csWOP#61 "Nordwürttemberg"
+// * include $csWOP#62 "Südwürttemberg"


### PR DESCRIPTION
fixes #55 
korrigiert gleichzeitig Tippfehler, der zu Validierungsfehler geführt hat