### PR TITLE
Canonical URL von VSDMVersichertenartPKVCS angepasst

### DIFF
--- a/src/fhir/fsh-generated/data/fsh-index.json
+++ b/src/fhir/fsh-generated/data/fsh-index.json
@@ -213,7 +213,7 @@
     "fshType": "CodeSystem",
     "fshFile": "codesystems/VSDMVersichertenartPKVCS.fsh",
     "startLine": 1,
-    "endLine": 14
+    "endLine": 21
   },
   {
     "outputFile": "ConceptMap-VSDMErrorcodeIssueSeverity.json",

--- a/src/fhir/fsh-generated/fsh-index.txt
+++ b/src/fhir/fsh-generated/fsh-index.txt
@@ -25,7 +25,7 @@ Bundle-019aa697-f160-72cd-b2eb-923d24dcce1a.json                        VSDMBund
 CodeSystem-VSDMErrorcodeCS.json                                         VSDMErrorcodeCS                                   CodeSystem  codesystems/VSDMErrorcodeCS.fsh                                1 - 23
 CodeSystem-VSDMKostentraegerRolleCS.json                                VSDMKostentraegerRolleCS                          CodeSystem  codesystems/VSDMKostentraegerRolleCS.fsh                       1 - 13
 CodeSystem-VSDMRuhenderLeistungsanspruchArtCS.json                      VSDMRuhenderLeistungsanspruchArtCS                CodeSystem  codesystems/VSDMRuhenderLeistungsanspruchArtCS.fsh             1 - 16
-CodeSystem-VSDMVersichertenartPKVCS.json                                VSDMVersichertenartPKVCS                          CodeSystem  codesystems/VSDMVersichertenartPKVCS.fsh                       1 - 14
+CodeSystem-VSDMVersichertenartPKVCS.json                                VSDMVersichertenartPKVCS                          CodeSystem  codesystems/VSDMVersichertenartPKVCS.fsh                       1 - 21
 ConceptMap-VSDMErrorcodeIssueSeverity.json                              VSDMErrorcodeIssueSeverity                        Instance    mappings/VSDMErrorcodeIssueSeverity.fsh                        1 - 101
 ConceptMap-VSDMErrorcodeIssueType.json                                  VSDMErrorcodeIssueType                            Instance    mappings/VSDMErrorcodeIssueType.fsh                            1 - 112
 OperationOutcome-VSDMOperationOutcome-InternalServerError.json          VSDMOperationOutcome-InternalServerError          Instance    examples/VSDMOperationOutcome-InternalServerError.fsh          1 - 20

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-8e77-7f16-be44-d702d1b6af67.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-8e77-7f16-be44-d702d1b6af67.json
@@ -129,7 +129,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VN",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "Versicherungsnehmer"
             }
           },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-ac5d-779a-8691-5f755f10deeb.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-ac5d-779a-8691-5f755f10deeb.json
@@ -132,7 +132,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VN",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "Versicherungsnehmer"
             }
           },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-bd25-77dd-836d-83543d1f2819.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-bd25-77dd-836d-83543d1f2819.json
@@ -159,7 +159,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VN",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "Versicherungsnehmer"
             }
           },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-cb86-73e1-868c-f7d408bf40ad.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-cb86-73e1-868c-f7d408bf40ad.json
@@ -170,7 +170,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VN",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "Versicherungsnehmer"
             }
           },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-db1f-74d9-a45b-2af3322f4c55.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-db1f-74d9-a45b-2af3322f4c55.json
@@ -136,7 +136,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VP",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "versicherte Person"
             }
           },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-ea3b-7096-963f-f880b94c70fd.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-ea3b-7096-963f-f880b94c70fd.json
@@ -142,7 +142,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VN",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "Versicherungsnehmer"
             }
           },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-fa51-7296-8ee8-1e7e7f9b9e2a.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-fa51-7296-8ee8-1e7e7f9b9e2a.json
@@ -121,7 +121,7 @@
             "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
             "valueCoding": {
               "code": "VN",
-              "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+              "system": "http://fhir.de/ValueSet/pkv/Versichertenart",
               "display": "Versicherungsnehmer"
             }
           },

--- a/src/fhir/fsh-generated/resources/CodeSystem-VSDMVersichertenartPKVCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-VSDMVersichertenartPKVCS.json
@@ -7,7 +7,7 @@
   "title": "Versichertenart (PKV)",
   "description": "PKV-Versichertenart im Versichertenstammdatenmanagement (VSDM) 2.0",
   "version": "1.0.0",
-  "url": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS",
+  "url": "http://fhir.de/ValueSet/pkv/Versichertenart",
   "concept": [
     {
       "code": "VN",

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMVersichertenartPKVVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMVersichertenartPKVVS.json
@@ -13,7 +13,7 @@
   "compose": {
     "include": [
       {
-        "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMVersichertenartPKVCS"
+        "system": "http://fhir.de/ValueSet/pkv/Versichertenart"
       }
     ]
   }

--- a/src/fhir/input/fsh/codesystems/VSDMVersichertenartPKVCS.fsh
+++ b/src/fhir/input/fsh/codesystems/VSDMVersichertenartPKVCS.fsh
@@ -6,6 +6,13 @@ Description: "PKV-Versichertenart im Versichertenstammdatenmanagement (VSDM) 2.0
 * ^caseSensitive = true
 * ^content = #complete
 
+// Dieses CodeSystem wird absehbar durch ein identisches CodeSystem aus dem deutschen Basisprofil bzw. dem zugehörigen Terminologiepaket ersetzt.
+// (vgl. https://github.com/hl7germany/basisprofil-de-r4/pull/667)
+// Das "neue" CodeSystem wird aber erst nach dem geplanten Veröffentlichungsdatum zur Verfügung stehen.
+// Um einen breaking change zu vermeiden, erhält dieses CodeSystem wie im TC FHIR am 27.11.2025 besprochen jetzt schon die finale canonical URL.
+// Nach Veröffentlichung des neuen CodeSystem (voraussichtlich in Q1/2026) und Aktualisierung der Paketabhängigkeiten kann dieses CodeSystem dann entfallen.
+* ^url = "http://fhir.de/ValueSet/pkv/Versichertenart"
+
 * #VN "Versicherungsnehmer"
   * ^definition = """
       Die behandelte Person ist selbst der Versicherungsnehmer.


### PR DESCRIPTION
Das CodeSystem VSDMVersichertenartPKVCS wird absehbar durch ein identisches CodeSystem aus dem deutschen Basisprofil bzw. dem zugehörigen Terminologiepaket ersetzt (vgl. #59 und https://github.com/hl7germany/basisprofil-de-r4/pull/667).
Das "neue" CodeSystem wird aber erst in Q1/2026, also nach dem geplanten Veröffentlichungsdatum der ersten Version von VSDM 2.0 zur Verfügung stehen.
Um einen breaking change zu vermeiden, erhält dieses CodeSystem wie im TC FHIR am 27.11.2025 besprochen jetzt schon die finale canonical URL.