### PR TITLE
Canonical URL von VSDMRuhenderLeistungsanspruchArtCS angepasst

### DIFF
--- a/src/fhir/fsh-generated/data/fsh-index.json
+++ b/src/fhir/fsh-generated/data/fsh-index.json
@@ -205,7 +205,7 @@
     "fshType": "CodeSystem",
     "fshFile": "codesystems/VSDMRuhenderLeistungsanspruchArtCS.fsh",
     "startLine": 1,
-    "endLine": 16
+    "endLine": 23
   },
   {
     "outputFile": "CodeSystem-VSDMVersichertenartPKVCS.json",

--- a/src/fhir/fsh-generated/fsh-index.txt
+++ b/src/fhir/fsh-generated/fsh-index.txt
@@ -24,7 +24,7 @@ Bundle-019aa697-e026-7735-b898-09ead32a7fa5.json                        VSDMBund
 Bundle-019aa697-f160-72cd-b2eb-923d24dcce1a.json                        VSDMBundle-GKV-B234567895                         Instance    examples/VSDMBundle-GKV-B234567895.fsh                         1 - 24
 CodeSystem-VSDMErrorcodeCS.json                                         VSDMErrorcodeCS                                   CodeSystem  codesystems/VSDMErrorcodeCS.fsh                                1 - 23
 CodeSystem-VSDMKostentraegerRolleCS.json                                VSDMKostentraegerRolleCS                          CodeSystem  codesystems/VSDMKostentraegerRolleCS.fsh                       1 - 13
-CodeSystem-VSDMRuhenderLeistungsanspruchArtCS.json                      VSDMRuhenderLeistungsanspruchArtCS                CodeSystem  codesystems/VSDMRuhenderLeistungsanspruchArtCS.fsh             1 - 16
+CodeSystem-VSDMRuhenderLeistungsanspruchArtCS.json                      VSDMRuhenderLeistungsanspruchArtCS                CodeSystem  codesystems/VSDMRuhenderLeistungsanspruchArtCS.fsh             1 - 23
 CodeSystem-VSDMVersichertenartPKVCS.json                                VSDMVersichertenartPKVCS                          CodeSystem  codesystems/VSDMVersichertenartPKVCS.fsh                       1 - 21
 ConceptMap-VSDMErrorcodeIssueSeverity.json                              VSDMErrorcodeIssueSeverity                        Instance    mappings/VSDMErrorcodeIssueSeverity.fsh                        1 - 101
 ConceptMap-VSDMErrorcodeIssueType.json                                  VSDMErrorcodeIssueType                            Instance    mappings/VSDMErrorcodeIssueType.fsh                            1 - 112

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-0b30-7415-95c1-85b85718f5e5.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-0b30-7415-95c1-85b85718f5e5.json
@@ -301,7 +301,7 @@
                 "url": "art",
                 "valueCoding": {
                   "code": "1",
-                  "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS",
+                  "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
                   "display": "vollständig"
                 }
               },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-614f-72d8-82f2-e993e395476f.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-614f-72d8-82f2-e993e395476f.json
@@ -150,7 +150,7 @@
                 "url": "art",
                 "valueCoding": {
                   "code": "2",
-                  "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS",
+                  "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
                   "display": "eingeschränkt"
                 }
               },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-6fff-70ea-b912-a69e99e4e4bc.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-6fff-70ea-b912-a69e99e4e4bc.json
@@ -247,7 +247,7 @@
                 "url": "art",
                 "valueCoding": {
                   "code": "1",
-                  "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS",
+                  "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
                   "display": "vollständig"
                 }
               },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-a20c-737c-ba9d-a1c58f4e7356.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-a20c-737c-ba9d-a1c58f4e7356.json
@@ -175,7 +175,7 @@
                 "url": "art",
                 "valueCoding": {
                   "code": "2",
-                  "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS",
+                  "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
                   "display": "eingeschränkt"
                 }
               },

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-b14e-7875-b470-c30f8c00de1b.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-b14e-7875-b470-c30f8c00de1b.json
@@ -171,7 +171,7 @@
                 "url": "art",
                 "valueCoding": {
                   "code": "1",
-                  "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS",
+                  "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
                   "display": "vollständig"
                 }
               },

--- a/src/fhir/fsh-generated/resources/CodeSystem-VSDMRuhenderLeistungsanspruchArtCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-VSDMRuhenderLeistungsanspruchArtCS.json
@@ -7,7 +7,7 @@
   "title": "Art des ruhenden Leistungsanspruchs",
   "description": "Art des ruhenden Leistungsanspruchs im Versichertenstammdatenmanagement (VSDM) 2.0",
   "version": "1.0.0",
-  "url": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS",
+  "url": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
   "concept": [
     {
       "code": "1",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoverageGKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoverageGKV.json
@@ -295,7 +295,7 @@
       {
         "id": "Coverage.extension:ruhenderLeistungsanspruch.extension:art.value[x].system",
         "path": "Coverage.extension.extension.value[x].system",
-        "fixedUri": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS"
+        "fixedUri": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV"
       },
       {
         "id": "Coverage.extension:ruhenderLeistungsanspruch.extension:dauer",

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMRuhenderLeistungsanspruchArtVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMRuhenderLeistungsanspruchArtVS.json
@@ -13,7 +13,7 @@
   "compose": {
     "include": [
       {
-        "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMRuhenderLeistungsanspruchArtCS"
+        "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV"
       }
     ]
   }

--- a/src/fhir/input/fsh/codesystems/VSDMRuhenderLeistungsanspruchArtCS.fsh
+++ b/src/fhir/input/fsh/codesystems/VSDMRuhenderLeistungsanspruchArtCS.fsh
@@ -12,8 +12,12 @@ Description: "Art des ruhenden Leistungsanspruchs im Versichertenstammdatenmanag
     Die von diesem CodeSystem definierten Werte wurden durch die gematik zur Einführung von VSDM 1 im Jahr 2011 festgelegt und werden hier für die Verwendung in FHIR-Profilen zugänglich gemacht.
   """
 
+// Dieses CodeSystem wird absehbar durch ein identisches CodeSystem aus dem deutschen Basisprofil bzw. dem zugehörigen Terminologiepaket ersetzt.
+// (vgl. https://github.com/hl7germany/basisprofil-de-r4/pull/666)
+// Das "neue" CodeSystem wird aber erst nach dem geplanten Veröffentlichungsdatum zur Verfügung stehen.
+// Um einen breaking change zu vermeiden, erhält dieses CodeSystem wie im TC FHIR am 27.11.2025 besprochen jetzt schon die finale canonical URL.
+// Nach Veröffentlichung des neuen CodeSystem (voraussichtlich in Q1/2026) und Aktualisierung der Paketabhängigkeiten kann dieses CodeSystem dann entfallen.
+* ^url = "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV"
+
 * #1 "vollständig"
 * #2 "eingeschränkt"
-
-// TODO Umzug in deutsches Basisprofil klären
-// Alexander Groß (gematik) 03.09.2025: ist intern in Klärung


### PR DESCRIPTION
Das CodeSystem VSDMRuhenderLeistungsanspruchArtCS wird absehbar durch ein identisches CodeSystem aus dem deutschen Basisprofil bzw. dem zugehörigen Terminologiepaket ersetzt (vgl. https://github.com/gematik/spec-VSDM2/issues/53 und https://github.com/hl7germany/basisprofil-de-r4/pull/663).
Das "neue" CodeSystem wird aber erst in Q1/2026, also nach dem geplanten Veröffentlichungsdatum der ersten Version von VSDM 2.0 zur Verfügung stehen.
Um einen breaking change zu vermeiden, erhält dieses CodeSystem wie im TC FHIR am 27.11.2025 besprochen jetzt schon die finale canonical URL.