### PR TITLE
Hinzufügen des Endpunkts für Fachdienstlokalisierung (C_12681)

### DIFF
--- a/src/openapi/fachdienstlokalisierung.yaml
+++ b/src/openapi/fachdienstlokalisierung.yaml
@@ -89,7 +89,7 @@ components:
             The time-to-live in seconds for the cached metadata. This is the maximum
             time that the metadata should be cached before it needs to be refreshed.
       example:
-        resourceFqdn: https://{resource_fqdn}.de
+        resourceFqdn: https://{resource_fqdn}
         scheme: https
         cacheTtl: 86400
     Problem:

--- a/src/openapi/vsdm2.yaml
+++ b/src/openapi/vsdm2.yaml
@@ -21,7 +21,7 @@ externalDocs:
   description: FHIR Specification VSDM 2
   url: https://simplifier.net/vsdm2
 servers:
-  - url: https://{resource_fqdn}.de
+  - url: https://{resource_fqdn}
     description: Example Hostname for a given VSDM service, taken from the /.well-known/ti-service-provider-metadata "Fachdienstlokalisierung" Endpoint of the ZETA HTTP proxy
 tags:
   - name: Vsdm
@@ -427,7 +427,7 @@ components:
       description: This API uses OAuth 2, to gain access clients need an Access-Token and to proof "Versorgungskontext" with a PoPP-Token in addition
       flows:
         authorizationCode:
-          authorizationUrl: https://{resource_fqdn}.de/auth
-          tokenUrl: https://{resource_fqdn}.de.de/token
+          authorizationUrl: https://{resource_fqdn}/auth
+          tokenUrl: https://{resource_fqdn}/token
           scopes:
             vsdservice: allows practitioners to access the VSDService API of the "Versichertenstammdatendienst"


### PR DESCRIPTION
Es gibt ca. 9 Fachdienst VSDM 2 Betreiber, die von 94 gesetzliche Krankenkassen beauftragt werden bzw. in einer vertraglichen Beziehung mit diesen stehen. Die Vergangenheit hat gezeigt, dass es des öfteren vorkommt, dass Krankenkassen den Betreiber wechseln. Ein Primärsystem kennt auf Basis der IK-NR immer nur die die Krankenkasse zu einem bestimmten Patienten, jedoch nicht bei welchem Betreiber die Krankenkasse aktuell ist.

Die VSDM 2.0 Spezifikation sieht eine Service/Betreiber-Discovery zur Ermittlung des aktuellen Betreibers eines Kostenträgers auf Basis der IK-NR und DNS mit CNAME vor. Anfragen vom VSDM-Clientsystem an den ZETA-Client erfolgen somit aktuell immer mit dem FQDN bzw. HTTP Host Parameter "<ik_nr>.prod.vsdm2.ti-dienste.de", wodurch sich folgende Probleme ergeben:

1. Der ZETA-Client kann das protected resource metadata Dokument nicht standardkonform gemäß https://www.rfc-editor.org/rfc/rfc9728.html#name-protected-resource-metadata-v abrufen und verarbeiten, wodurch die VSDM-spezifischen ZETA-Konfiguratonen nicht ermittelt werden können.
2. Anfragen am /authorize Endpunkt des AuthZ-Server resultieren aufgrund des Kostenträger-spezifischen claims "aud" in der Anfrage in Kostenträger-spezifische Access-Token. Dies führt zu n (mit n = Anzahl der Kassen) durch das Primärsystem zu verwaltende Access-Token, da der ZETA Client vom VSDM2 Client mit einem kompletten HTTP Request (mit genau einer URL == Audience) angefragt wird und auf Basis dessen ein Access- und Refresh-Token immer für die angeforderte Audience (Endpunkt des RS) und zugehörigem Scope ausgestellt wird.
3. Anfragen an den /vsdmservice Endpunkt des Resource Server resultieren aufgrund des Kostenträger-spezifischen HOST Parameter im HTTP-Request des Primärsystem in ebenso Kostenträger-spezifische ASL-Kanäle. Dies führt bis zu n (mit n = Anzahl der Kassen) durch das Primärsystem zu verwaltende ASL-Kanäle bzw. ASL Schlüsselpaare, da ein ASL Kanal immer für einen bestimmten Host (== FQDN im CNAME) aufgebaut werden muss.

Der hier skizzierte Lösungsvorschlag sieht vor, den kurzfristig im ZETA-Guard eingebauten Fachdienstlokalisierungs-Endpunkt zu nutzen, um damit die darauffolgenden Abläufe standardkonform vornehmen zu können. Dabei werden Änderungen sowohl am VSDM2-Clientverhalten vorgenommen, als auch mit Referenz zum ZETA-Guard beschrieben.

Die Änderung basiert auf dem Vorabveröffentlichungspaket [gemSpec_VSDM_2_V1.4.0_CC](https://gemspec.gematik.de/prereleases/Draft_VSDM2_26_1/gemSpec_VSDM_2_V1.4.0_CC/)