### PR TITLE
Version 1.1.0 erstellt

### DIFF
--- a/CHANGELOG-FHIR.md
+++ b/CHANGELOG-FHIR.md
@@ -9,6 +9,20 @@ Historische Release Notes (vor Beginn dieser Aufzeichnung) wurden zum Teil unbea
 
 ### Neu
 
+### Änderung
+
+### Abkündigung
+
+### Entfernung
+
+### Fehlerbehebung
+
+### Security
+
+## [1.1.0] - 2026-07-03
+
+### Neu
+
 - Es wurde ein neues Basis-Profil VSDMCoverageGKVBase zwischen dem deutschen Basisprofil und dem bereits bestehenden Profil VSDMCoverageGKV eingezogen, um die Umsetzung der EEB zu unterstützen.
   Durch diese Änderung ergeben sich keine inhaltlichen Änderungen an den VSDM 2.0-Ressourcen.
   ([issue 171](https://github.com/gematik/spec-VSDM2/issues/171))
@@ -62,6 +76,8 @@ Historische Release Notes (vor Beginn dieser Aufzeichnung) wurden zum Teil unbea
 
 ### Abkündigung
 
+(keine)
+
 ### Entfernung
 
 - Das CodeSystem VSDMRuhenderLeistungsanspruchArtCS und das zugehörige ValueSet VSDMRuhenderLeistungsanspruchArtVS wurden durch die inhaltsgleichen Versionen aus dem deutschen Basisprofil ersetzt.
@@ -80,6 +96,8 @@ Historische Release Notes (vor Beginn dieser Aufzeichnung) wurden zum Teil unbea
   ([issue 174](https://github.com/gematik/spec-VSDM2/issues/175))
 
 ### Security
+
+(keine)
 
 ## [1.0.1] - 2026-05-20
 
@@ -237,3 +255,4 @@ _(Release Notes aus der Simplifier-Veröffentlichung übernommen)_
 [1.0.0-rc8]: https://simplifier.net/packages/de.gematik.vsdm2/1.0.0-rc8
 [1.0.0]: https://simplifier.net/packages/de.gematik.vsdm2/1.0.0
 [1.0.1]: https://simplifier.net/packages/de.gematik.vsdm2/1.0.1
+[1.1.0]: https://simplifier.net/packages/de.gematik.vsdm2/1.1.0

--- a/docs/fhir_release.md
+++ b/docs/fhir_release.md
@@ -22,6 +22,7 @@ Checkliste:
   - das Datum in den Metadaten-Rulesets aktualisieren (sollte dreimal vorkommen)
 - In der Datei `package.json` die Versionsangabe ersetzen
 - In allen Dateien mit der Endung `.fsh` den Text `|<Version-alt>)` ersetzen durch `|<Version-neu>)` (also z.B. `|1.0.0-rc7)` durch `|1.0.0-rc8)`)
+- In allen Dateien mit der Endung `.fsh` den Text `<Version-alt>` suchen, manuell prüfen und ersetzen durch `<Version-neu>`
 - FHIR-Ressourcen aus den FSH-Quellen neu erzeugen (Aufruf von `sushi` - später mal `ig`)
 - Validierungsergebnisse prüfen und eventuelle Fehler beheben
 - zur Absicherung gesamtes Projekt nach altem Datum und alter Versionsnummer durchsuchen (sollte außer im Changelog keine Treffer mehr ergeben)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "de.gematik.spec-vsdv2",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "fhirVersions": [
     "4.0.1"
   ],

--- a/src/fhir/fsh-generated/resources/Bundle-019aa690-d14a-79a3-a078-3807df1b87f4.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa690-d14a-79a3-a078-3807df1b87f4.json
@@ -3,7 +3,7 @@
   "id": "019aa690-d14a-79a3-a078-3807df1b87f4",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-9c4e-7540-be3c-0ef324476863",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -99,7 +99,7 @@
         "id": "019aa696-775a-7062-8e34-ad28ac640060",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -158,7 +158,7 @@
         "id": "019aa692-9527-7cd9-8a94-0370d748ead9",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-8e77-7f16-be44-d702d1b6af67.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-8e77-7f16-be44-d702d1b6af67.json
@@ -3,7 +3,7 @@
   "id": "019aa696-8e77-7f16-be44-d702d1b6af67",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-3bb4-7dcf-a4ba-3322947d55dc",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -105,7 +105,7 @@
         "id": "019aa694-dbf0-7207-abd6-bcb7b65dab35",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -192,7 +192,7 @@
         "id": "019aa698-5ee2-7d61-8f09-c93fb5c18f95",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-ac5d-779a-8691-5f755f10deeb.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-ac5d-779a-8691-5f755f10deeb.json
@@ -3,7 +3,7 @@
   "id": "019aa696-ac5d-779a-8691-5f755f10deeb",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-4d88-7efc-8b76-73f2e3afd5e7",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -108,7 +108,7 @@
         "id": "019aa694-edc7-7231-9184-c2910d4cf37f",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -195,7 +195,7 @@
         "id": "019aa690-ed54-74bb-9acf-d15af64e00d3",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-bd25-77dd-836d-83543d1f2819.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-bd25-77dd-836d-83543d1f2819.json
@@ -3,7 +3,7 @@
   "id": "019aa696-bd25-77dd-836d-83543d1f2819",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-609d-7da9-8344-99aef4564d7f",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -135,7 +135,7 @@
         "id": "019aa694-fd12-70dd-9861-370e431a0227",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -218,7 +218,7 @@
         "id": "019aa691-0595-7235-8c71-f9bfc5cc579c",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-cb86-73e1-868c-f7d408bf40ad.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-cb86-73e1-868c-f7d408bf40ad.json
@@ -3,7 +3,7 @@
   "id": "019aa696-cb86-73e1-868c-f7d408bf40ad",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-6fb9-7553-a456-b40a01819bad",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -147,7 +147,7 @@
         "id": "019aa695-0ba8-79d0-8126-05de77db0da8",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -226,7 +226,7 @@
         "id": "019aa691-1976-7d0c-9698-44625e754464",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-db1f-74d9-a45b-2af3322f4c55.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-db1f-74d9-a45b-2af3322f4c55.json
@@ -3,7 +3,7 @@
   "id": "019aa696-db1f-74d9-a45b-2af3322f4c55",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-7f8b-71e0-87d5-b6c2f4aee454",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -113,7 +113,7 @@
         "id": "019aa695-1a2a-7c65-9348-067355fa7655",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -209,7 +209,7 @@
         "id": "019aa691-3a52-7536-acd9-2ec675894780",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-ea3b-7096-963f-f880b94c70fd.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-ea3b-7096-963f-f880b94c70fd.json
@@ -3,7 +3,7 @@
   "id": "019aa696-ea3b-7096-963f-f880b94c70fd",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-8ee9-7328-9a10-31f6e689787a",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -118,7 +118,7 @@
         "id": "019aa695-29cf-7efd-ba64-6d827477212f",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -202,7 +202,7 @@
         "id": "019aa691-5647-7b09-905e-e0130ecd0bbd",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa696-fa51-7296-8ee8-1e7e7f9b9e2a.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa696-fa51-7296-8ee8-1e7e7f9b9e2a.json
@@ -3,7 +3,7 @@
   "id": "019aa696-fa51-7296-8ee8-1e7e7f9b9e2a",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-9ea6-7def-832d-27bb1eb8997f",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -97,7 +97,7 @@
         "id": "019aa695-3789-79be-a29b-88d8183eebe5",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV|1.1.0"
           ]
         },
         "status": "active",
@@ -189,7 +189,7 @@
         "id": "019aa691-6ac1-7cb4-94fe-c2bce5e1a343",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-0b30-7415-95c1-85b85718f5e5.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-0b30-7415-95c1-85b85718f5e5.json
@@ -3,7 +3,7 @@
   "id": "019aa697-0b30-7415-95c1-85b85718f5e5",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-b177-79c2-a927-39ec2d7486df",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -180,7 +180,7 @@
         "id": "019aa695-45d8-7343-819f-904c6038d5ab",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -361,7 +361,7 @@
         "id": "019aa690-b557-71a4-9cf3-7076092e7574",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [
@@ -404,7 +404,7 @@
         "id": "019aa693-2b6d-7df7-aa3a-5bfbd19c0c79",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-19f6-77e3-a394-ea9948e9e019.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-19f6-77e3-a394-ea9948e9e019.json
@@ -3,7 +3,7 @@
   "id": "019aa697-19f6-77e3-a394-ea9948e9e019",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-bff6-7e85-9a84-e4ad7f8dd48c",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -108,7 +108,7 @@
         "id": "019aa695-6296-743f-a1d0-f3a354ed1475",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -180,7 +180,7 @@
         "id": "019aa691-efa4-7cfc-8f83-82387d397bce",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-29dd-7ad1-a12c-32a14b4ed62b.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-29dd-7ad1-a12c-32a14b4ed62b.json
@@ -3,7 +3,7 @@
   "id": "019aa697-29dd-7ad1-a12c-32a14b4ed62b",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-d14a-7370-bdb9-19b88d14f8d1",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -99,7 +99,7 @@
         "id": "019aa695-89de-7f4d-852f-0a8d9802e333",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -200,7 +200,7 @@
         "id": "019aa691-a2d5-76a6-b3a0-f2210545a698",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [
@@ -243,7 +243,7 @@
         "id": "019aa691-7b2d-741f-b40f-0eefa2596dd6",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-3a4c-7303-be74-43a250b6c5dd.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-3a4c-7303-be74-43a250b6c5dd.json
@@ -3,7 +3,7 @@
   "id": "019aa697-3a4c-7303-be74-43a250b6c5dd",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-e2f4-750d-a4a3-d76f636546c1",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -108,7 +108,7 @@
         "id": "019aa695-9d92-7975-8da5-9daea4e1d463",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -180,7 +180,7 @@
         "id": "019aa691-8f0b-7b18-83e0-ce95b4bb6722",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-51f0-7259-8059-ba2e44cd6360.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-51f0-7259-8059-ba2e44cd6360.json
@@ -3,7 +3,7 @@
   "id": "019aa697-51f0-7259-8059-ba2e44cd6360",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa693-f5c1-7f37-a51f-0cffee08db71",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -99,7 +99,7 @@
         "id": "019aa695-ad4a-787f-b8f4-a13e81110e87",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -216,7 +216,7 @@
         "id": "019aa693-005c-7770-a3b5-870d536e2163",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-614f-72d8-82f2-e993e395476f.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-614f-72d8-82f2-e993e395476f.json
@@ -3,7 +3,7 @@
   "id": "019aa697-614f-72d8-82f2-e993e395476f",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-042b-7240-98e0-2ea7952c3fec",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -95,7 +95,7 @@
         "id": "019aa695-bcf0-7225-b707-8f15c0710b3c",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -204,7 +204,7 @@
         "id": "019aa692-4c73-750d-ac25-19ba533f5031",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [
@@ -247,7 +247,7 @@
         "id": "019aa692-2475-7b66-9662-0056c28a32b0",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-6fff-70ea-b912-a69e99e4e4bc.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-6fff-70ea-b912-a69e99e4e4bc.json
@@ -3,7 +3,7 @@
   "id": "019aa697-6fff-70ea-b912-a69e99e4e4bc",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-120e-7e8a-8f0b-701ea96908c8",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -137,7 +137,7 @@
         "id": "019aa695-cf21-730d-9e2c-2d7013b2db6d",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -298,7 +298,7 @@
         "id": "019aa692-12b4-7a0b-be02-e700d52127d5",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-806f-7c2e-9e3b-d4d8df01c218.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-806f-7c2e-9e3b-d4d8df01c218.json
@@ -3,7 +3,7 @@
   "id": "019aa697-806f-7c2e-9e3b-d4d8df01c218",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-2007-76e7-80d0-37887bfb769f",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -99,7 +99,7 @@
         "id": "019aa695-dec6-7b78-8014-c666bcc0d4a1",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -205,7 +205,7 @@
         "id": "019aa691-c9ed-7311-8dde-26b7aeafaa08",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-92a2-71bf-8eaf-310acac70f0e.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-92a2-71bf-8eaf-310acac70f0e.json
@@ -3,7 +3,7 @@
   "id": "019aa697-92a2-71bf-8eaf-310acac70f0e",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-3009-76be-8a8a-854f04af6f3d",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -125,7 +125,7 @@
         "id": "019aa695-f016-7aee-9ee9-a8577aabdbc7",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -265,7 +265,7 @@
         "id": "019aa693-0f20-7aea-81ff-debae0183f14",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [
@@ -308,7 +308,7 @@
         "id": "019aa693-1e11-74eb-9916-91d4b3071351",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-a20c-737c-ba9d-a1c58f4e7356.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-a20c-737c-ba9d-a1c58f4e7356.json
@@ -3,7 +3,7 @@
   "id": "019aa697-a20c-737c-ba9d-a1c58f4e7356",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-4344-78ca-899f-b73d841475b1",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -107,7 +107,7 @@
         "id": "019aa696-021a-72bf-b9fa-3fd5e56ba94b",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -221,7 +221,7 @@
         "id": "019aa692-5ee9-74c7-bcda-af99e8358094",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-b14e-7875-b470-c30f8c00de1b.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-b14e-7875-b470-c30f8c00de1b.json
@@ -3,7 +3,7 @@
   "id": "019aa697-b14e-7875-b470-c30f8c00de1b",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-512a-7308-81bd-cffd96cec457",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -116,7 +116,7 @@
         "id": "019aa696-1070-728a-ad84-4b44e373daac",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -218,7 +218,7 @@
         "id": "019aa691-fec3-79c7-bd58-5538f03fea37",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-c1ff-73b0-a222-ca57e6f14a96.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-c1ff-73b0-a222-ca57e6f14a96.json
@@ -3,7 +3,7 @@
   "id": "019aa697-c1ff-73b0-a222-ca57e6f14a96",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-5fec-7003-9b99-6a81eea5b057",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -145,7 +145,7 @@
         "id": "019aa696-38b1-78a5-a3e9-b10cd6e0a34d",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -296,7 +296,7 @@
         "id": "019aa692-3896-74e3-a3f5-ee54b04411e5",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [
@@ -339,7 +339,7 @@
         "id": "019aa692-8168-7b40-8893-eed9305defcb",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-d1e9-7c8b-a283-34cfeae9fc8e.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-d1e9-7c8b-a283-34cfeae9fc8e.json
@@ -3,7 +3,7 @@
   "id": "019aa697-d1e9-7c8b-a283-34cfeae9fc8e",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-6f37-72b0-89ea-042e20e449a8",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -163,7 +163,7 @@
         "id": "019aa696-4962-7577-9a24-9be92b1dde93",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -276,7 +276,7 @@
         "id": "019aa692-6f84-7efd-bb81-1a4ebbff8075",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-e026-7735-b898-09ead32a7fa5.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-e026-7735-b898-09ead32a7fa5.json
@@ -3,7 +3,7 @@
   "id": "019aa697-e026-7735-b898-09ead32a7fa5",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-7e82-76ba-9b71-cbb1456f219e",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -121,7 +121,7 @@
         "id": "019aa696-5a70-7a68-ad1c-83b7369f7049",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -251,7 +251,7 @@
         "id": "019aa691-dd16-7d29-a3e0-f84ab48b9db0",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019aa697-f160-72cd-b2eb-923d24dcce1a.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019aa697-f160-72cd-b2eb-923d24dcce1a.json
@@ -3,7 +3,7 @@
   "id": "019aa697-f160-72cd-b2eb-923d24dcce1a",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019aa694-8cec-78d8-aadb-cb6af636e899",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -120,7 +120,7 @@
         "id": "019aa696-69e7-79e0-8cb2-8149ab064196",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -197,7 +197,7 @@
         "id": "019aa692-edfe-7659-bd03-1b492c557077",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [
@@ -240,7 +240,7 @@
         "id": "019aa692-a944-756a-bc42-e857b709b862",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/Bundle-019b0758-2d32-7576-99c7-f90818235c4f.json
+++ b/src/fhir/fsh-generated/resources/Bundle-019b0758-2d32-7576-99c7-f90818235c4f.json
@@ -3,7 +3,7 @@
   "id": "019b0758-2d32-7576-99c7-f90818235c4f",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle|1.1.0"
     ],
     "lastUpdated": "2025-07-14T15:16:17.890+01:00"
   },
@@ -17,7 +17,7 @@
         "id": "019b0758-985e-7703-b4f7-c5064736aed2",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient|1.1.0"
           ]
         },
         "identifier": [
@@ -72,7 +72,7 @@
                 {
                   "valueCoding": {
                     "system": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMISO3166ErgaenzungCS",
-                    "version": "1.1.0-dev",
+                    "version": "1.1.0",
                     "code": "XK"
                   },
                   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMISO3166Ergaenzung"
@@ -100,7 +100,7 @@
         "id": "019b0758-5ce0-7711-a5da-cffbb256cffd",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV|1.1.0"
           ]
         },
         "status": "active",
@@ -172,7 +172,7 @@
         "id": "019aa691-efa4-7cfc-8f83-82387d397bce",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0-dev"
+            "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization|1.1.0"
           ]
         },
         "identifier": [

--- a/src/fhir/fsh-generated/resources/CodeSystem-VSDMErrorcodeCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-VSDMErrorcodeCS.json
@@ -6,7 +6,7 @@
   "id": "VSDMErrorcodeCS",
   "title": "VSDM-Fehlercodes",
   "description": "Fachspezifische Fehlercodes im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMErrorcodeCS",
   "concept": [
     {
@@ -155,7 +155,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "caseSensitive": true,
   "purpose": "Dieses CodeSystem enthält die an das Clientsystem zu sendenden fachspezifischen Fehlercodes im Versichertenstammdatenmanagement (VSDM) 2.0.\nFür diese Fehlercodes wird eine Fehlerbeschreibung in Form einer VSDMOperationOutcome-Struktur erzeugt, die dann einen Fehlercode aus diesem CodeSystem enthält.\nDie Definition der einzelnen Codes enthält den Meldungstext, der als narrative content für den Anwender des Clientsystems bestimmt ist.\nDie Eigenschaft diagnostics enthält die technischen Zusatzinformationen, die im Element VSDMOperationOutcome.issue.diagnostics der Antwortstruktur angegeben werden sollen.",
   "property": [

--- a/src/fhir/fsh-generated/resources/CodeSystem-VSDMISO3166ErgaenzungCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-VSDMISO3166ErgaenzungCS.json
@@ -6,7 +6,7 @@
   "id": "VSDMISO3166ErgaenzungCS",
   "title": "ergänzende Ländercodes",
   "description": "ergänzende Ländercodes zu ISO 3166-1 im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMISO3166ErgaenzungCS",
   "concept": [
     {
@@ -56,7 +56,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "caseSensitive": true,
   "purpose": "Im VSDM 2.0 werden Länderkennungen in Adressdaten grundsätzlich nach ISO 3166-1 und für den GKV-Bereich zusätzlich nach DEÜV Anlage 8 kodiert.\nDie DEÜV spiegelt den Stand in den Quellsystemen, aus denen die VSDM 2.0-Fachdienste versorgt werden, wieder.\nIn der DEÜV gibt es Ländercodes, die sich nicht auf den zum Zeitpunkt der Veröffentlichung bestehenden Stand der ISO 3166-1 abbilden lassen.\nDieses CodeSystem enthält zusätzlichen Ländercodes, um eine verlustfreie Abbildung zu ermöglichen.",
   "count": 2

--- a/src/fhir/fsh-generated/resources/CodeSystem-VSDMTDSCodeCS.json
+++ b/src/fhir/fsh-generated/resources/CodeSystem-VSDMTDSCodeCS.json
@@ -6,7 +6,7 @@
   "id": "VSDMTDSCodeCS",
   "title": "VSDM-TDS-Codes",
   "description": "Fehlercodes des Telemetriedatenservice (TDS) im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS",
   "concept": [
     {
@@ -235,7 +235,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "caseSensitive": true,
   "purpose": "Dieses CodeSystem enthält alle Fehlercodes des Telemetriedatenservice (TDS), der Fachdienst gemäß Anforderung A_27012-02 und darin enthaltener Tabelle TAB_FACHDIENST_VSDM_FEHLERREFERENZEN_UND_FEHLERCODES sowie den bei den jeweiligen Codes genanntnen Anforderungen liefern muss.\nDiese TDS-Codes decken alle in der Spezifikation vorgesehenen Fehlersituationen ab.\nDieses CodeSystem definiert die genauen Fehlerzustände und dient als Ausgangspunkt für verschiedene Zuordnungen (ConceptMaps).\nJe nach Fehlerquelle werden diese Fehler entweder an das Clientsystem oder an den HTTP Proxy des ZETA Guard adressiert.\nNur für die Fehlercodes mit Adressat \"Clientsystem\" wird eine Fehlerbeschreibung in Form einer VSDMOperationOutcome-Struktur erzeugt, die dann einen Fehlercode aus dem CodeSystem VSDMErrorcodeCS enthält.",
   "property": [

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMDEUEVAnlage8ISO3166.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMDEUEVAnlage8ISO3166.json
@@ -6,7 +6,7 @@
   "description": "Ermittlung des Ländercodes nach ISO 3166-1 aus dem Ländercode nach DEÜV Anlage 8",
   "status": "active",
   "experimental": false,
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -30,7 +30,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Diese ConceptMap ordnet den Ländercodes aus der DEÜV Anlage 8 die korrespondierenden offiziellen Ländercodes nach ISO 3166-1 zu.",
   "sourceUri": "https://fhir.kbv.de/ValueSet/KBV_VS_Base_Deuev_Anlage_8",
   "targetUri": "http://hl7.org/fhir/ValueSet/iso3166-1-2",

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMDEUEVAnlage8ISO3166Ergaenzung.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMDEUEVAnlage8ISO3166Ergaenzung.json
@@ -6,7 +6,7 @@
   "description": "Ermittlung des vorläufigen Ländercodes nach ISO 3166-1 aus dem Ländercode nach DEÜV Anlage 8",
   "status": "active",
   "experimental": false,
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -30,14 +30,14 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Diese ConceptMap ordnet den Ländercodes aus der DEÜV Anlage 8 die vorläufigen Ländercodes in Anlehnung an ISO 3166-1 zu.\nZur Ablage dieser Werte ist eine separate Extension zu verwenden (siehe Profilierung der jeweiligen Address-Strukturen).",
   "sourceUri": "https://fhir.kbv.de/ValueSet/KBV_VS_Base_Deuev_Anlage_8",
-  "targetUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMISO3166ErgaenzungVS|1.1.0-dev",
+  "targetUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMISO3166ErgaenzungVS|1.1.0",
   "group": [
     {
       "source": "http://fhir.de/CodeSystem/deuev/anlage-8-laenderkennzeichen",
-      "target": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMISO3166ErgaenzungCS|1.1.0-dev",
+      "target": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMISO3166ErgaenzungCS|1.1.0",
       "element": [
         {
           "code": "KOS",

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeErrorcode.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeErrorcode.json
@@ -6,7 +6,7 @@
   "description": "Ermittlung des VSDMErrorcode aus dem TDS-Code",
   "status": "active",
   "experimental": false,
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -30,14 +30,14 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Diese ConceptMap ordnet den TDS-Codes die VSDMErrorcodes gemäß Tabelle TAB_FACHDIENST_VSDM_FEHLERREFERENZEN_UND_FEHLERCODES aus Anforderung A_27012-01 zu.\nWichtig: Hier werden nur die TDS-Codes mit Fehler-Adressat \"Clientsystem\" erfasst, da für Fehler mit Adressat \"HTTP-Proxy\" keine VSDMOperationOutcome-Ressource erzeugt wird.",
-  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0-dev",
-  "targetUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMErrorcodeVS|1.1.0-dev",
+  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0",
+  "targetUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMErrorcodeVS|1.1.0",
   "group": [
     {
-      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0-dev",
-      "target": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMErrorcodeCS|1.1.0-dev",
+      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0",
+      "target": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMErrorcodeCS|1.1.0",
       "element": [
         {
           "code": "79010",

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeHTTPStatus.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeHTTPStatus.json
@@ -6,7 +6,7 @@
   "description": "Ermittlung des HTTP Status aus dem TDSCode",
   "status": "active",
   "experimental": false,
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -30,12 +30,12 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Diese ConceptMap ordnet den TDS-Codes die HTTP Status Codes aus Tabelle TAB_FACHDIENST_VSDM_HTTP_STATUS_CODES zu.",
-  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0-dev",
+  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0",
   "group": [
     {
-      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0-dev",
+      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0",
       "element": [
         {
           "code": "79010",

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeIssueSeverity.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeIssueSeverity.json
@@ -6,7 +6,7 @@
   "description": "Ermittlung der IssueSeverity aus dem VSDMTDSCode",
   "status": "active",
   "experimental": false,
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -30,13 +30,13 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Diese ConceptMap ordnet den TDS-Codes die Werte zur Versorgung von VSDMOperationOutcome.issue.severity zu.\nWichtig: Hier werden nur die TDS-Codes mit Fehler-Adressat \"Clientsystem\" erfasst, da für Fehler mit Adressat \"HTTP-Proxy\" keine VSDMOperationOutcome-Ressource erzeugt wird.",
-  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0-dev",
+  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0",
   "targetUri": "http://hl7.org/fhir/ValueSet/issue-severity",
   "group": [
     {
-      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0-dev",
+      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0",
       "target": "http://hl7.org/fhir/issue-severity",
       "element": [
         {

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeIssueType.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeIssueType.json
@@ -6,7 +6,7 @@
   "description": "Ermittlung des IssueType aus dem VSDMTDSCode",
   "status": "active",
   "experimental": false,
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -30,13 +30,13 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Diese ConceptMap ordnet den TDS-Codes die Werte zur Versorgung von VSDMOperationOutcome.issue.code zu.\nWichtig: Hier werden nur die TDS-Codes mit Fehler-Adressat \"Clientsystem\" erfasst, da für Fehler mit Adressat \"HTTP-Proxy\" keine VSDMOperationOutcome-Ressource erzeugt wird.",
-  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0-dev",
+  "sourceUri": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS|1.1.0",
   "targetUri": "http://hl7.org/fhir/ValueSet/issue-type",
   "group": [
     {
-      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0-dev",
+      "source": "https://gematik.de/fhir/vsdm2/CodeSystem/VSDMTDSCodeCS|1.1.0",
       "target": "http://hl7.org/fhir/issue-type",
       "element": [
         {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InternalServerError.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InternalServerError.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-InternalServerError",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidHTTPOperation.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidHTTPOperation.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-InvalidHTTPOperation",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidHeader.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidHeader.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-InvalidHeader",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidIK.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidIK.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-InvalidIK",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidKVNR.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidKVNR.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-InvalidKVNR",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidProfileVersion.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-InvalidProfileVersion.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-InvalidProfileVersion",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-MissingPatientRecordVersion.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-MissingPatientRecordVersion.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-MissingPatientRecordVersion",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-MissingProfileVersion.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-MissingProfileVersion.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-MissingProfileVersion",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnknownIK.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnknownIK.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-UnknownIK",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnknownKVNR.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnknownKVNR.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-UnknownKVNR",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnsupportedMediatype.json
+++ b/src/fhir/fsh-generated/resources/OperationOutcome-VSDMOperationOutcome-UnsupportedMediatype.json
@@ -3,7 +3,7 @@
   "id": "VSDMOperationOutcome-UnsupportedMediatype",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0-dev"
+      "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome|1.1.0"
     ]
   },
   "text": {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMBeihilfe.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMBeihilfe.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMBeihilfe",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBeihilfe",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMBeihilfe",
   "title": "Beihilfeanspruch",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMBundle.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMBundle.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMBundle",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMBundle",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMBundle",
   "title": "Versichertenstammdaten",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMContactPointTIM.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMContactPointTIM.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMContactPointTIM",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMContactPointTIM",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMContactPointTIM",
   "title": "TI-Messenger-ID",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoverageGKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoverageGKV.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMCoverageGKV",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKV",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMCoverageGKV",
   "title": "Versicherungsdaten GKV",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoverageGKVBase.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoverageGKVBase.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMCoverageGKVBase",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoverageGKVBase",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMCoverageGKVBase",
   "title": "Versicherungsdaten GKV (Basis)",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoveragePKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMCoveragePKV.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMCoveragePKV",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMCoveragePKV",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMCoveragePKV",
   "title": "Versicherungsdaten PKV",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMDMPTeilnahme.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMDMPTeilnahme.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMDMPTeilnahme",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMDMPTeilnahme",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMDMPTeilnahme",
   "title": "Teilnahme an Disease Management-Programm",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMHinweisPKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMHinweisPKV.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMHinweisPKV",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMHinweisPKV",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMHinweisPKV",
   "title": "Hinweise an PKV-Leistungserbringer",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMISO3166Ergaenzung.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMISO3166Ergaenzung.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMISO3166Ergaenzung",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMISO3166Ergaenzung",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMISO3166Ergaenzung",
   "title": "ergänzende Ländercodes",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {
@@ -86,7 +86,7 @@
         "id": "Extension.value[x].version",
         "path": "Extension.value[x].version",
         "min": 1,
-        "fixedString": "1.1.0-dev",
+        "fixedString": "1.1.0",
         "mustSupport": true
       },
       {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMKrankenhausleistungenPKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMKrankenhausleistungenPKV.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMKrankenhausleistungenPKV",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMKrankenhausleistungenPKV",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMKrankenhausleistungenPKV",
   "title": "PKV-Kostenübernahme Krankenhausleistungen",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMLaenderkennzeichenAnlage8.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMLaenderkennzeichenAnlage8.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMLaenderkennzeichenAnlage8",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMLaenderkennzeichenAnlage8",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMLaenderkennzeichenAnlage8",
   "title": "Land (Anlage 8 DEÜV)",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMOperationOutcome.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMOperationOutcome.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMOperationOutcome",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMOperationOutcome",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMOperationOutcome",
   "title": "Fehlermeldung des VSDM Resource Servers",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMPatient.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMPatient.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMPatient",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPatient",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMPatient",
   "title": "Versicherter",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMPayorOrganization.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMPayorOrganization.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMPayorOrganization",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMPayorOrganization",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMPayorOrganization",
   "title": "Kostenträger",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMTarifartPKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMTarifartPKV.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMTarifartPKV",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMTarifartPKV",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMTarifartPKV",
   "title": "PKV-Tarifart",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-VSDMVersichertenartPKV.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-VSDMVersichertenartPKV.json
@@ -2,12 +2,12 @@
   "resourceType": "StructureDefinition",
   "id": "VSDMVersichertenartPKV",
   "url": "https://gematik.de/fhir/vsdm2/StructureDefinition/VSDMVersichertenartPKV",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "name": "VSDMVersichertenartPKV",
   "title": "Versichertenart (PKV)",
   "status": "active",
   "experimental": false,
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "publisher": "gematik GmbH",
   "contact": [
     {

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMDMPVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMDMPVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMDMPVS",
   "title": "Disease-Management-Programm (DMP)",
   "description": "Disease-Management-Programm im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMDMPVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "purpose": "Das CodeSystem der Disease-Management-Programme enthält alle auf der eGK hinterlegbaren Werte.\nDazu gehören auch Kombinationswerte, z.B. 33 für COPD und KHK, sowie ein Nullwert.\nDiese Kombinationswerte sind zur Ablage auf der eGK erforderlich (eng beschränkter Speicherbereich).\nFür VSDM 2.0 sind diese Sonderwerte allerdings nicht mehr sinnvoll:\nDie Disease-Management-Programme werden als wiederholbare Struktur mit separaten Gültigkeitsbereichen und weiteren Attributen ausgeführt.\nEin Nullwert wird ebenfalls nicht mehr benötigt.\nDieses ValueSet nimmt daher eine Einschränkung des KBV-CodeSystem auf im VSDM 2.0 gültige Werte vor.\nDa einige Abkürzungen aus dem CodeSystem nicht unbedingt allgemeinverständlich sind, ergänzt das ValueSet die Konzepte um einen Beschreibungstext.",
   "compose": {
     "include": [

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMErrorcodeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMErrorcodeVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMErrorcodeVS",
   "title": "VSDM-Fehlercodes",
   "description": "Fehlercodes im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMErrorcodeVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "compose": {
     "include": [
       {

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMISO3166ErgaenzungVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMISO3166ErgaenzungVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMISO3166ErgaenzungVS",
   "title": "ergänzende Ländercodes",
   "description": "ergänzende Ländercodes zu ISO 3166-1 im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMISO3166ErgaenzungVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "compose": {
     "include": [
       {

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMNamenszusatzVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMNamenszusatzVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMNamenszusatzVS",
   "title": "Namenszusatz",
   "description": "Namenszusatz nach DEÜV Anlage 7 im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMNamenszusatzVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "compose": {
     "include": [
       {

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMTDSCodeVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMTDSCodeVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMTDSCodeVS",
   "title": "VSDM-TDS-Codes",
   "description": "Fehlercodes der Betriebsdatenerfassung (TDS) im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMTDSCodeVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "compose": {
     "include": [
       {

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMVorsatzwortVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMVorsatzwortVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMVorsatzwortVS",
   "title": "Namensvorsatzwort",
   "description": "Namensvorsatzwort nach DEÜV Anlage 6 im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMVorsatzwortVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "compose": {
     "include": [
       {

--- a/src/fhir/fsh-generated/resources/ValueSet-VSDMWohnortprinzipVS.json
+++ b/src/fhir/fsh-generated/resources/ValueSet-VSDMWohnortprinzipVS.json
@@ -5,7 +5,7 @@
   "id": "VSDMWohnortprinzipVS",
   "title": "Wohnortprinzip (WOP)",
   "description": "Wohnortprinzip im Versichertenstammdatenmanagement (VSDM) 2.0",
-  "version": "1.1.0-dev",
+  "version": "1.1.0",
   "url": "https://gematik.de/fhir/vsdm2/ValueSet/VSDMWohnortprinzipVS",
   "experimental": false,
   "publisher": "gematik GmbH",
@@ -31,7 +31,7 @@
       ]
     }
   ],
-  "date": "2026-05-20",
+  "date": "2026-07-03",
   "compose": {
     "include": [
       {

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-100390876.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-100390876.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Rostock"
 Description: "Beispielkostenträger Rostock"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "100390876"
 * name = "Beispielkostenträger Rostock"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-100412075.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-100412075.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Neubrandenburg"
 Description: "Beispielkostenträger Neubrandenburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "100412075"
 * name = "Beispielkostenträger Neubrandenburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-100629189.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-100629189.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Potsdam"
 Description: "Beispielkostenträger Potsdam"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "100629189"
 * name = "Beispielkostenträger Potsdam"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-100767109.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-100767109.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Cottbus"
 Description: "Beispielkostenträger Cottbus"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "100767109"
 * name = "Beispielkostenträger Cottbus"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-100837864.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-100837864.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Frankfurt an der Oder"
 Description: "Beispielkostenträger Frankfurt an der Oder"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "100837864"
 * name = "Beispielkostenträger Frankfurt an der Oder"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101084423.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101084423.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Magdeburg"
 Description: "Beispielkostenträger Magdeburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101084423"
 * name = "Beispielkostenträger Magdeburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101138358.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101138358.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Halle"
 Description: "Beispielkostenträger Halle"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101138358"
 * name = "Beispielkostenträger Halle"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101229542.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101229542.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Dessau"
 Description: "Beispielkostenträger Dessau"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101229542"
 * name = "Beispielkostenträger Dessau"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101316991.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101316991.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Schleswig-Holstein"
 Description: "Beispielkostenträger Schleswig-Holstein"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101316991"
 * name = "Beispielkostenträger Schleswig-Holstein"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101593043.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101593043.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Hamburg"
 Description: "Beispielkostenträger Hamburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101593043"
 * name = "Beispielkostenträger Hamburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101831688.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101831688.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Aurich"
 Description: "Beispielkostenträger Aurich"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101831688"
 * name = "Beispielkostenträger Aurich"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-101904345.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-101904345.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Braunschweig"
 Description: "Beispielkostenträger Braunschweig"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "101904345"
 * name = "Beispielkostenträger Braunschweig"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-102060928.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-102060928.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Göttingen"
 Description: "Beispielkostenträger Göttingen"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102060928"
 * name = "Beispielkostenträger Göttingen"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-102462343.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-102462343.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Oldenburg"
 Description: "Beispielkostenträger Oldenburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102462343"
 * name = "Beispielkostenträger Oldenburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-102546957.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-102546957.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Osnabrück"
 Description: "Beispielkostenträger Osnabrück"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102546957"
 * name = "Beispielkostenträger Osnabrück"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-102618749.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-102618749.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Stade"
 Description: "Beispielkostenträger Stade"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102618749"
 * name = "Beispielkostenträger Stade"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-102722735.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-102722735.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Verden"
 Description: "Beispielkostenträger Verden"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102722735"
 * name = "Beispielkostenträger Verden"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-102828457.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-102828457.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Wilhelmshaven"
 Description: "Beispielkostenträger Wilhelmshaven"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102828457"
 * name = "Beispielkostenträger Wilhelmshaven"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-103539039.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-103539039.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Dortmund"
 Description: "Beispielkostenträger Dortmund"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "103539039"
 * name = "Beispielkostenträger Dortmund"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-103707692.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-103707692.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Münster"
 Description: "Beispielkostenträger Münster"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "103707692"
 * name = "Beispielkostenträger Münster"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-104252310.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-104252310.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Düsseldorf"
 Description: "Beispielkostenträger Düsseldorf"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104252310"
 * name = "Beispielkostenträger Düsseldorf"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-104487108.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-104487108.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Duisburg"
 Description: "Beispielkostenträger Duisburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104487108"
 * name = "Beispielkostenträger Duisburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-104686063.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-104686063.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Köln"
 Description: "Beispielkostenträger Köln"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104686063"
 * name = "Beispielkostenträger Köln"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-104812556.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-104812556.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Krefeld"
 Description: "Beispielkostenträger Krefeld"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104812556"
 * name = "Beispielkostenträger Krefeld"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-104945099.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-104945099.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Wuppertal"
 Description: "Beispielkostenträger Wuppertal"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104945099"
 * name = "Beispielkostenträger Wuppertal"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-105395861.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-105395861.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Frankfurt"
 Description: "Beispielkostenträger Frankfurt"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105395861"
 * name = "Beispielkostenträger Frankfurt"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-105698629.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-105698629.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Limburg"
 Description: "Beispielkostenträger Limburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105698629"
 * name = "Beispielkostenträger Limburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-105763413.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-105763413.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Marburg"
 Description: "Beispielkostenträger Marburg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105763413"
 * name = "Beispielkostenträger Marburg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-105816575.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-105816575.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Wiesbaden"
 Description: "Beispielkostenträger Wiesbaden"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105816575"
 * name = "Beispielkostenträger Wiesbaden"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-106044960.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-106044960.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Gera"
 Description: "Beispielkostenträger Gera"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106044960"
 * name = "Beispielkostenträger Gera"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-106145699.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-106145699.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Suhl"
 Description: "Beispielkostenträger Suhl"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106145699"
 * name = "Beispielkostenträger Suhl"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-106270260.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-106270260.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Rheinhessen"
 Description: "Beispielkostenträger Rheinhessen"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106270260"
 * name = "Beispielkostenträger Rheinhessen"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-106498173.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-106498173.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Pfalz"
 Description: "Beispielkostenträger Pfalz"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106498173"
 * name = "Beispielkostenträger Pfalz"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-106597231.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-106597231.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Trier"
 Description: "Beispielkostenträger Trier"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106597231"
 * name = "Beispielkostenträger Trier"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-106967901.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-106967901.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Karlsruhe"
 Description: "Beispielkostenträger Karlsruhe"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106967901"
 * name = "Beispielkostenträger Karlsruhe"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-107078689.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-107078689.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Mannheim"
 Description: "Beispielkostenträger Mannheim"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107078689"
 * name = "Beispielkostenträger Mannheim"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-107170568.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-107170568.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Pforzheim"
 Description: "Beispielkostenträger Pforzheim"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107170568"
 * name = "Beispielkostenträger Pforzheim"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-107546344.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-107546344.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Konstanz"
 Description: "Beispielkostenträger Konstanz"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107546344"
 * name = "Beispielkostenträger Konstanz"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-107837745.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-107837745.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Süd-Württemberg"
 Description: "Beispielkostenträger Süd-Württemberg"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107837745"
 * name = "Beispielkostenträger Süd-Württemberg"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-108546756.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-108546756.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Oberbayern"
 Description: "Beispielkostenträger Oberbayern"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108546756"
 * name = "Beispielkostenträger Oberbayern"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-108606009.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-108606009.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Oberfranken"
 Description: "Beispielkostenträger Oberfranken"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108606009"
 * name = "Beispielkostenträger Oberfranken"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-108750061.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-108750061.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Mittelfranken"
 Description: "Beispielkostenträger Mittelfranken"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108750061"
 * name = "Beispielkostenträger Mittelfranken"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-108846691.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-108846691.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Unterfranken"
 Description: "Beispielkostenträger Unterfranken"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108846691"
 * name = "Beispielkostenträger Unterfranken"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-108918482.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-108918482.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Oberpfalz"
 Description: "Beispielkostenträger Oberpfalz"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108918482"
 * name = "Beispielkostenträger Oberpfalz"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-109149007.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-109149007.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Schwaben"
 Description: "Beispielkostenträger Schwaben"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "109149007"
 * name = "Beispielkostenträger Schwaben"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-109323112.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-109323112.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Saarland"
 Description: "Beispielkostenträger Saarland"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "109323112"
 * name = "Beispielkostenträger Saarland"

--- a/src/fhir/input/backup/examples/VSDMPayorOrganization-109504155.fsh
+++ b/src/fhir/input/backup/examples/VSDMPayorOrganization-109504155.fsh
@@ -4,7 +4,7 @@ Title: "Beispielkostenträger Berlin"
 Description: "Beispielkostenträger Berlin"
 Usage: #inline
 
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "109504155"
 * name = "Beispielkostenträger Berlin"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-A123456780.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-A123456780.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-A123456780
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten A123456780 Amsel, Andrea (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-A123456780
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "A123456780"
 * birthDate = "1997-12-28"
@@ -56,7 +56,7 @@ Description: "Versicherungsdaten A123456780 Amsel, Andrea (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-A123456780
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#38 "Nordrhein"
 * extension[versichertenart].valueCoding = $csVersichertenartGKV|1.02#1 "Mitglieder"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-B234567895.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-B234567895.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-B234567895
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -31,7 +31,7 @@ Description: "Versichertendaten B234567895 Graf von und zu Buntspecht, Bernd Ben
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-B234567895
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "B234567895"
 * birthDate = "1988-06-22"
@@ -63,7 +63,7 @@ Description: "Versicherungsdaten B234567895 Graf von und zu Buntspecht, Bernd Be
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-B234567895
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#03 "Bremen"
 * extension[besonderePersonengruppe].valueCoding = #04 "SOZ" // "BSHG (Bundessozialhilfegesetz) § 264 SGB V"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-C345678908.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-C345678908.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-C345678908
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten C345678908 Carolinataube, Charlie (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-C345678908
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "C345678908"
 * birthDate = "1979-06-11"
@@ -59,7 +59,7 @@ Description: "Versicherungsdaten C345678908 Carolinataube, Charlie (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-C345678908
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#98 "Sachsen"
 * extension[dmp][+]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-D456789013.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-D456789013.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-D456789013
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten D456789013 Dohle, Dara (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-D456789013
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "D456789013"
 * birthDate = "1970-01-20"
@@ -67,7 +67,7 @@ Description: "Versicherungsdaten D456789013 Dohle, Dara (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-D456789013
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#46 "Hessen"
 * extension[besonderePersonengruppe].valueCoding = #06 "SER" // "SER (Soziales Entschädigungsrecht)"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-E567890127.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-E567890127.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-E567890127
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -31,7 +31,7 @@ Description: "Versichertendaten E567890127 Freifrau an der Elster, Elke (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-E567890127
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "E567890127"
 * birthDate = "1992-11-13"
@@ -69,7 +69,7 @@ Description: "Versicherungsdaten E567890127 Freifrau an der Elster, Elke (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-E567890127
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#93 "Thüringen"
 * extension[zuzahlungsstatus]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-F678901231.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-F678901231.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-F678901231
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten F678901231 von Fasan, Frank Florian (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-F678901231
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "F678901231"
 * birthDate = "1983-01-19"
@@ -59,7 +59,7 @@ Description: "Versicherungsdaten F678901231 von Fasan, Frank Florian (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-F678901231
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#52 "Baden-Württemberg"
 * extension[besonderePersonengruppe].valueCoding = #08 "SVA2" // "SVA-Kennzeichnung, pauschal"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-G789012344.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-G789012344.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-G789012344
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten G789012344 Edle von der Graugans, Gabriele (GKV)
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-G789012344
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "G789012344"
 * birthDate = "1974-02-12"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten G789012344 Edle von der Graugans, Gabriele (GKV
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-G789012344
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#46 "Hessen"
 * extension[zuzahlungsstatus]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-H890123459.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-H890123459.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-H890123459
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -31,7 +31,7 @@ Description: "Versichertendaten H890123459 vorm Habicht, Hans (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-H890123459
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "H890123459"
 * birthDate = "1953-07-29"
@@ -64,7 +64,7 @@ Description: "Versicherungsdaten H890123459 vorm Habicht, Hans (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-H890123459
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#17 "Niedersachsen"
 * extension[besonderePersonengruppe].valueCoding = #07 "SVA1" // "SVA-Kennzeichnung für zwischenstaatliches Krankenversicherungsrecht: - Personen mit Wohnsitz im Inland, Abrechnung nach Aufwand"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-I901234562.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-I901234562.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-I901234562
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten I901234562 Ibis, Ingrid (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-I901234562
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "I901234562"
 * birthDate = "1942-02-28"
@@ -56,7 +56,7 @@ Description: "Versicherungsdaten I901234562 Ibis, Ingrid (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-I901234562
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#98 "Sachsen"
 * extension[dmp][+]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-J012345677.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-J012345677.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-J012345677
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten J012345677 Junko, Jens-Jörg (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-J012345677
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "J012345677"
 * birthDate = "1958-12"
@@ -64,7 +64,7 @@ Description: "Versicherungsdaten J012345677 Junko, Jens-Jörg (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-J012345677
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#52 "Baden-Württemberg"
 * extension[besonderePersonengruppe].valueCoding = #09 "ASY" // "Empfänger von Gesundheitsleistungen nach §§ 4 und 6 des Asylbewerberleistungsgesetzes (AsylbLG)"

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-K123456781.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-K123456781.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-K123456781
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -31,7 +31,7 @@ Description: "Versichertendaten K123456781 Kiebitz, Karin (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-K123456781
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "K123456781"
 * birthDate = "1933"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten K123456781 Kiebitz, Karin (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-K123456781
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#46 "Hessen"
 * extension[kostenerstattung]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-L234567896.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-L234567896.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-L234567896
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten L234567896 Lachmöwe, Lisa (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-L234567896
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "L234567896"
 * birthDate = "2022-07-02"
@@ -56,7 +56,7 @@ Description: "Versicherungsdaten L234567896 Lachmöwe, Lisa (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-L234567896
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#17 "Niedersachsen"
 * extension[dmp][+]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-M345678909.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-M345678909.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-M345678909
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten M345678909 Mittelspecht, Michael-Martin (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-M345678909
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "M345678909"
 * birthDate = "2020-04-27"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten M345678909 Mittelspecht, Michael-Martin (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-M345678909
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#71 "Bayern"
 * extension[zuzahlungsstatus]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-N456789014.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-N456789014.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-N456789014
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -31,7 +31,7 @@ Description: "Versichertendaten N456789014 Nachtigall, Nina Nicole (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-N456789014
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "N456789014"
 * birthDate = "2011-06-22"
@@ -59,7 +59,7 @@ Description: "Versicherungsdaten N456789014 Nachtigall, Nina Nicole (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-N456789014
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#52 "Baden-Württemberg"
 * extension[zuzahlungsstatus]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-O567890128.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-O567890128.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-O567890128
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten O567890128 Ortolan, Oliver (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-O567890128
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "O567890128"
 * birthDate = "2009-06-08"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten O567890128 Ortolan, Oliver (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-O567890128
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#52 "Baden-Württemberg"
 * extension[zuzahlungsstatus]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-P678901232.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-P678901232.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-P678901232
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten P678901232 Pinguin, Paula (GKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-P678901232
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "P678901232"
 * birthDate = "2009-06-08"
@@ -45,7 +45,7 @@ Usage: #inline
   * city = "Prishtina"
   * postalCode = "10000"
   * country = "Kosovo"
-    * extension[countryCodeExt].valueCoding = VSDMISO3166ErgaenzungCS|1.1.0-dev#XK
+    * extension[countryCodeExt].valueCoding = VSDMISO3166ErgaenzungCS|1.1.0#XK
     * extension[anlage8].valueCoding = $csAnlage8Laenderkennzeichen#KOS
 
 
@@ -56,7 +56,7 @@ Description: "Versicherungsdaten P678901232 Pinguin, Paula (GKV)"
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-P678901232
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#52 "Baden-Württemberg"
 * extension[zuzahlungsstatus]

--- a/src/fhir/input/fsh/examples/VSDMExample-GKV-Z987654321.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-GKV-Z987654321.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-GKV-Z987654321
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -31,7 +31,7 @@ Description: "Versichertendaten Z987654321 Graf von und zu Zaunkönig, Zacharias
 Usage: #inline
 
 * id = $idVSDMPatient-GKV-Z987654321
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "Z987654321"
 * birthDate = "1987-05-16"
@@ -74,7 +74,7 @@ Description: "Versicherungsdaten Z987654321 Graf von und zu Zaunkönig, Zacharia
 Usage: #inline
 
 * id = $idVSDMCoverageGKV-Z987654321
-* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoverageGKV|1.1.0)
 
 * extension[WOP].valueCoding = $csWOP|1.00#98 "Sachsen"
 * extension[dmp][+]

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-A123456780.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-A123456780.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-A123456780
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten A123456780 Amsel, Andrea (PKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-A123456780
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "A123456780"
 * birthDate = "1997-12-28"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten A123456780 Amsel, Andrea (PKV)"
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-A123456780
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[hinweis]
   * extension[text].valueMarkdown = "Beihilfetaxe für Physio"

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-B234567895.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-B234567895.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-B234567895
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten B234567895 Graf von und zu Buntspecht, Bernd Ben
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-B234567895
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "B234567895"
 * birthDate = "1988-06-22"
@@ -62,7 +62,7 @@ Description: "Versicherungsdaten B234567895 Graf von und zu Buntspecht, Bernd Be
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-B234567895
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[krankenhaus]
   * extension[allgemein].valueUnsignedInt = 100

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-C345678908.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-C345678908.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-C345678908
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten C345678908 Carolinataube, Charlie (PKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-C345678908
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "C345678908"
 * birthDate = "1979-06-11"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten C345678908 Carolinataube, Charlie (PKV)"
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-C345678908
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[krankenhaus]
   * extension[allgemein].valueUnsignedInt = 100

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-D456789013.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-D456789013.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-D456789013
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten D456789013 Dohle, Dara (PKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-D456789013
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "D456789013"
 * birthDate = "1970-01-20"
@@ -65,7 +65,7 @@ Description: "Versicherungsdaten D456789013 Dohle, Dara (PKV)"
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-D456789013
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[krankenhaus]
   * extension[allgemein].valueUnsignedInt = 100

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-E567890127.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-E567890127.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-E567890127
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten E567890127 Freifrau an der Elster, Elke (PKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-E567890127
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "E567890127"
 * birthDate = "1992-11-13"
@@ -67,7 +67,7 @@ Description: "Versicherungsdaten E567890127 Freifrau an der Elster, Elke (PKV)"
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-E567890127
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[krankenhaus]
   * extension[allgemein].valueUnsignedInt = 100

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-F678901231.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-F678901231.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-F678901231
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten F678901231 von Fasan, Frank Florian (PKV)"
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-F678901231
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "F678901231"
 * birthDate = "1983-01-19"
@@ -58,7 +58,7 @@ Description: "Versicherungsdaten F678901231 von Fasan, Frank Florian (PKV)"
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-F678901231
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[krankenhaus]
   * extension[allgemein].valueUnsignedInt = 100

--- a/src/fhir/input/fsh/examples/VSDMExample-PKV-G789012344.fsh
+++ b/src/fhir/input/fsh/examples/VSDMExample-PKV-G789012344.fsh
@@ -6,7 +6,7 @@ Usage: #example
 
 * id = $idVSDMBundle-PKV-G789012344
 * meta
-  * profile[0] = Canonical(VSDMBundle|1.1.0-dev)
+  * profile[0] = Canonical(VSDMBundle|1.1.0)
   * lastUpdated = "2025-07-14T15:16:17.890+01:00"
 * type = #collection
 * timestamp = "2025-07-14T15:16:17.890+01:00"
@@ -28,7 +28,7 @@ Description: "Versichertendaten G789012344 Edle von der Graugans, Gabriele (PKV)
 Usage: #inline
 
 * id = $idVSDMPatient-PKV-G789012344
-* meta.profile[0] = Canonical(VSDMPatient|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPatient|1.1.0)
 
 * identifier[KVNR].value = "G789012344"
 * birthDate = "1974-02-12"
@@ -60,7 +60,7 @@ Description: "Versicherungsdaten G789012344 Edle von der Graugans, Gabriele (PKV
 Usage: #inline
 
 * id = $idVSDMCoveragePKV-G789012344
-* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMCoveragePKV|1.1.0)
 
 * extension[krankenhaus]
   * extension[allgemein].valueUnsignedInt = 100

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InternalServerError.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InternalServerError.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Unerwarteter interner Fehler des Fachd
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidHTTPOperation.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidHTTPOperation.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Die HTTP-Operation '[http_operation]' 
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidHeader.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidHeader.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Der HTTP-Header '[header]' ist ungült
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidIK.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidIK.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Institutionskennung '[ik]' aus dem PoP
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidKVNR.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidKVNR.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Krankenversichertennummer '[kvnr]' aus
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidProfileVersion.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-InvalidProfileVersion.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Die vom Clientsystem angefragte Profil
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-MissingPatientRecordVersion.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-MissingPatientRecordVersion.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Der erforderliche Änderungsindikator 
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-MissingProfileVersion.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-MissingProfileVersion.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Der erforderliche Query-Parameter 'pro
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnknownIK.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnknownIK.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Institutionskennung '[ik]' aus dem PoP
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnknownKVNR.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnknownKVNR.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Krankenversichertennummer '[kvnr]' aus
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnsupportedMediatype.fsh
+++ b/src/fhir/input/fsh/examples/VSDMOperationOutcome-UnsupportedMediatype.fsh
@@ -5,7 +5,7 @@ Description: "Beispiel zur Fehlermeldung 'Das vom Clientsystem angefragte Datenf
 Usage: #example
 
 * meta
-  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0-dev)
+  * profile[0] = Canonical(VSDMOperationOutcome|1.1.0)
 * text
   * status = #generated
   * div[+] = """

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-100293710.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-100293710.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Schwerin"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-100293710
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "100293710"
 * name = "Beispielkostenträger Schwerin"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-102186348.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-102186348.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Hannover"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-102186348
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102186348"
 * name = "Beispielkostenträger Hannover"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-102249844.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-102249844.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Hildesheim"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-102249844
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102249844"
 * name = "Beispielkostenträger Hildesheim"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-102343996.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-102343996.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Lüneburg"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-102343996
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "102343996"
 * name = "Beispielkostenträger Lüneburg"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-103169760.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-103169760.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Bremen"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-103169760
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "103169760"
 * name = "Beispielkostenträger Bremen"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-103215857.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-103215857.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Bremerhaven"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-103215857
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "103215857"
 * name = "Beispielkostenträger Bremerhaven"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-104178397.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-104178397.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Aachen"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-104178397
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104178397"
 * name = "Beispielkostenträger Aachen"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-104547224.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-104547224.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Essen"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-104547224
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "104547224"
 * name = "Beispielkostenträger Essen"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-105266989.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-105266989.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Darmstadt"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-105266989
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105266989"
 * name = "Beispielkostenträger Darmstadt"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-105413578.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-105413578.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Gießen"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-105413578
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105413578"
 * name = "Beispielkostenträger Gießen"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-105532787.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-105532787.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Kassel"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-105532787
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105532787"
 * name = "Beispielkostenträger Kassel"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-105929412.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-105929412.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Erfurt"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-105929412
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "105929412"
 * name = "Beispielkostenträger Erfurt"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-106339922.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-106339922.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Koblenz"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-106339922
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106339922"
 * name = "Beispielkostenträger Koblenz"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-106877150.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-106877150.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Baden-Baden"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-106877150
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "106877150"
 * name = "Beispielkostenträger Baden-Baden"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-107403308.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-107403308.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Freiburg"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-107403308
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107403308"
 * name = "Beispielkostenträger Freiburg"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-107668422.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-107668422.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Offenburg"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-107668422
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107668422"
 * name = "Beispielkostenträger Offenburg"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-107723372.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-107723372.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Chemnitz"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-107723372
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107723372"
 * name = "Beispielkostenträger Chemnitz"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-107933230.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-107933230.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Dresden"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-107933230
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "107933230"
 * name = "Beispielkostenträger Dresden"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-108028771.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-108028771.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Nord-Württemberg"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-108028771
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108028771"
 * name = "Beispielkostenträger Nord-Württemberg"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-108213958.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-108213958.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Leipzig"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-108213958
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108213958"
 * name = "Beispielkostenträger Leipzig"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-108416806.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-108416806.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger München-Stadt"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-108416806
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "108416806"
 * name = "Beispielkostenträger München-Stadt"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-109083613.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-109083613.fsh
@@ -5,7 +5,7 @@ Description: "Beispielkostenträger Niederbayern"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-109083613
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "109083613"
 * name = "Beispielkostenträger Niederbayern"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168112342.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168112342.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Pluto"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168112342
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168112342"
 * name = "Privatversicherung Pluto"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168123458.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168123458.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Neptun"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168123458
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168123458"
 * name = "Privatversicherung Neptun"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168134565.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168134565.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Uranus"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168134565
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168134565"
 * name = "Privatversicherung Uranus"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168145671.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168145671.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Saturn"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168145671
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168145671"
 * name = "Privatversicherung Saturn"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168156788.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168156788.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Jupiter"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168156788
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168156788"
 * name = "Privatversicherung Jupiter"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168167894.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168167894.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Mars"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168167894
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168167894"
 * name = "Privatversicherung Mars"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168178900.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168178900.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Venus"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168178900
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168178900"
 * name = "Privatversicherung Venus"

--- a/src/fhir/input/fsh/examples/VSDMPayorOrganization-168189015.fsh
+++ b/src/fhir/input/fsh/examples/VSDMPayorOrganization-168189015.fsh
@@ -5,7 +5,7 @@ Description: "Privatversicherung Merkur"
 Usage: #inline
 
 * id = $idVSDMPayorOrganization-168189015
-* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0-dev)
+* meta.profile[0] = Canonical(VSDMPayorOrganization|1.1.0)
 
 * identifier[IKNR].value = "168189015"
 * name = "Privatversicherung Merkur"

--- a/src/fhir/input/fsh/extensions/VSDMISO3166Ergaenzung.fsh
+++ b/src/fhir/input/fsh/extensions/VSDMISO3166Ergaenzung.fsh
@@ -22,5 +22,5 @@ Description: "ergänzende Ländercodes zu ISO 3166-1 im Versichertenstammdatenma
   * system 1..
   * system = Canonical(VSDMISO3166ErgaenzungCS) (exactly)
   * version 1.. MS
-  * version = "1.1.0-dev" (exactly)
+  * version = "1.1.0" (exactly)
   * code 1.. MS

--- a/src/fhir/input/fsh/mappings/VSDMDEUEVAnlage8ISO3166Ergaenzung.fsh
+++ b/src/fhir/input/fsh/mappings/VSDMDEUEVAnlage8ISO3166Ergaenzung.fsh
@@ -11,10 +11,10 @@ Usage: #definition
   """
 
 * sourceUri = $vsAnlage8Laenderkennzeichen
-* targetUri = Canonical(VSDMISO3166ErgaenzungVS|1.1.0-dev)
+* targetUri = Canonical(VSDMISO3166ErgaenzungVS|1.1.0)
 * group[+]
   * source = $csAnlage8Laenderkennzeichen
-  * target = Canonical(VSDMISO3166ErgaenzungCS|1.1.0-dev)
+  * target = Canonical(VSDMISO3166ErgaenzungCS|1.1.0)
 
   * element[+]
     * code = #KOS

--- a/src/fhir/input/fsh/mappings/VSDMTDSCodeErrorcode.fsh
+++ b/src/fhir/input/fsh/mappings/VSDMTDSCodeErrorcode.fsh
@@ -10,11 +10,11 @@ Usage: #definition
     Wichtig: Hier werden nur die TDS-Codes mit Fehler-Adressat "Clientsystem" erfasst, da für Fehler mit Adressat "HTTP-Proxy" keine VSDMOperationOutcome-Ressource erzeugt wird.
   """
 
-* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0-dev)
-* targetUri = Canonical(VSDMErrorcodeVS|1.1.0-dev)
+* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0)
+* targetUri = Canonical(VSDMErrorcodeVS|1.1.0)
 * group[+]
-  * source = Canonical(VSDMTDSCodeCS|1.1.0-dev)
-  * target = Canonical(VSDMErrorcodeCS|1.1.0-dev)
+  * source = Canonical(VSDMTDSCodeCS|1.1.0)
+  * target = Canonical(VSDMErrorcodeCS|1.1.0)
 
   * element[+]
     * code = #79010

--- a/src/fhir/input/fsh/mappings/VSDMTDSCodeHTTPStatus.fsh
+++ b/src/fhir/input/fsh/mappings/VSDMTDSCodeHTTPStatus.fsh
@@ -9,9 +9,9 @@ Usage: #definition
     Diese ConceptMap ordnet den TDS-Codes die HTTP Status Codes aus Tabelle TAB_FACHDIENST_VSDM_HTTP_STATUS_CODES zu.
   """
 
-* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0-dev)
+* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0)
 * group[+]
-  * source = Canonical(VSDMTDSCodeCS|1.1.0-dev)
+  * source = Canonical(VSDMTDSCodeCS|1.1.0)
 
   * element[+]
     * code = #79010

--- a/src/fhir/input/fsh/mappings/VSDMTDSCodeIssueSeverity.fsh
+++ b/src/fhir/input/fsh/mappings/VSDMTDSCodeIssueSeverity.fsh
@@ -10,10 +10,10 @@ Usage: #definition
     Wichtig: Hier werden nur die TDS-Codes mit Fehler-Adressat "Clientsystem" erfasst, da für Fehler mit Adressat "HTTP-Proxy" keine VSDMOperationOutcome-Ressource erzeugt wird.
   """
 
-* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0-dev)
+* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0)
 * targetUri = $vsIssueSeverity
 * group[+]
-  * source = Canonical(VSDMTDSCodeCS|1.1.0-dev)
+  * source = Canonical(VSDMTDSCodeCS|1.1.0)
   * target = $csIssueSeverity
 
   * element[+]

--- a/src/fhir/input/fsh/mappings/VSDMTDSCodeIssueType.fsh
+++ b/src/fhir/input/fsh/mappings/VSDMTDSCodeIssueType.fsh
@@ -10,10 +10,10 @@ Usage: #definition
     Wichtig: Hier werden nur die TDS-Codes mit Fehler-Adressat "Clientsystem" erfasst, da für Fehler mit Adressat "HTTP-Proxy" keine VSDMOperationOutcome-Ressource erzeugt wird.
   """
 
-* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0-dev)
+* sourceUri = Canonical(VSDMTDSCodeVS|1.1.0)
 * targetUri = $vsIssueType
 * group[+]
-  * source = Canonical(VSDMTDSCodeCS|1.1.0-dev)
+  * source = Canonical(VSDMTDSCodeCS|1.1.0)
   * target = $csIssueType
 
   * element[+]

--- a/src/fhir/input/fsh/ruleset.fsh
+++ b/src/fhir/input/fsh/ruleset.fsh
@@ -5,36 +5,36 @@
 RuleSet: Meta
 * ^status = #active
 * ^experimental = false
-* ^version = "1.1.0-dev"
+* ^version = "1.1.0"
 * ^publisher = "gematik GmbH"
 * ^contact.name = "gematik GmbH"
 * ^contact.telecom.system = #url
 * ^contact.telecom.value = "https://fachportal.gematik.de/anwendungen/versichertenstammdaten-management"
 * ^jurisdiction = urn:iso:std:iso:3166#DE "Germany"
-* ^date = 2026-05-20
+* ^date = 2026-07-03
 
 RuleSet: Meta-CodeSystem
 * ^status = #active // Caution: CodeSystems with status "draft" trigger a validation error
 * ^experimental = false
-* ^version = "1.1.0-dev"
+* ^version = "1.1.0"
 * ^publisher = "gematik GmbH"
 * ^contact.name = "gematik GmbH"
 * ^contact.telecom.system = #url
 * ^contact.telecom.value = "https://fachportal.gematik.de/anwendungen/versichertenstammdaten-management"
 * ^jurisdiction = urn:iso:std:iso:3166#DE "Germany"
 * ^jurisdiction = urn:iso:std:iso:3166#DE "Germany"
-* ^date = 2026-05-20
+* ^date = 2026-07-03
 
 RuleSet: Meta-Inst
 * status = #active
 * experimental = false
-* version = "1.1.0-dev"
+* version = "1.1.0"
 * publisher = "gematik GmbH"
 * contact.name = "gematik GmbH"
 * contact.telecom.system = #url
 * contact.telecom.value = "https://fachportal.gematik.de/anwendungen/versichertenstammdaten-management"
 * jurisdiction = urn:iso:std:iso:3166#DE "Germany"
-* date = 2026-05-20
+* date = 2026-07-03
 
 // ================================================================================================
 //


### PR DESCRIPTION
### Neu

- Es wurde ein neues Basis-Profil VSDMCoverageGKVBase zwischen dem deutschen Basisprofil und dem bereits bestehenden Profil VSDMCoverageGKV eingezogen, um die Umsetzung der EEB zu unterstützen.
  Durch diese Änderung ergeben sich keine inhaltlichen Änderungen an den VSDM 2.0-Ressourcen.
  ([issue 171](https://github.com/gematik/spec-VSDM2/issues/171))

### Änderung

- Im CodeSystem VSDMTDSCodeCS wird für die Codes 79015 und 79016 jetzt ein Wert für das OperationOutcome-Element expression angegeben.
  ([issue 163](https://github.com/gematik/spec-VSDM2/issues/163))
- Die Kennzeichnung der Must Support-Elemente wurde an die Empfehlungen des HL7 Deutschland TC FHIR angepasst.
  ([issue 168](https://github.com/gematik/spec-VSDM2/issues/168))
- Das Paket verwendet jetzt das deutsche Basisprofil in Version 1.6.0 als Abhängigkeit.  
  ([issue 177](https://github.com/gematik/spec-VSDM2/issues/177))
- Zur Vermeidung/Behebung von Validierungsproblemen wird das Länderkennzeichen nach Anlage 8 DEÜV jetzt in einer eigenen Erweiterung abgelegt.
  Außerdem werden die Ergänzungswerte zu ISO 3166-1 in eine eigene Erweiterung ausgelagert (betrifft insbesondere Kosovo).
  ACHTUNG: Dadurch ändert sich die technische Abbildung der Werte (keine inhaltliche Änderung.)
  ([issue 175](https://github.com/gematik/spec-VSDM2/issues/175))
- Um die Nutzung von CodeSystem/ValueSet-Ressourcen aus verschiedenen Paketversionen stabil zu ermöglichen, wird für die folgenden kodierten Elemente die Angabe einer Versionsnummer verpflichtend gemacht
  ([issue 173](https://github.com/gematik/spec-VSDM2/issues/173)):
  - VSDMPatient:
    - Patient.gender.extension:other-amtlich
    - Patient.address.country.extension:countryCodeExt (VSDMISO3166Ergaenzung)
    - Patient.address.country.extension:anlage8 (VSDMISO3166Ergaenzung)
  - VSDMCoverageGKV:
    - Coverage.extension:dmp.extension:dmp (VSDMDMPTeilnahme)
    - Coverage.extension:WOP
    - Coverage.extension:besonderePersonengruppe
    - Coverage.extension:ruhenderLeistungsanspruch.extension:art
    - Coverage.extension:versichertenart
    - Coverage.type
  - VSDMCoveragePKV:
    - Coverage.extension:tarifart (VSDMTarifartPKV)
    - Coverage.extension:versichertenart (VSDMVersichertenartPKV)
    - Coverage.type
  - VSDMPayorOrganization
    - Organization.address.country.extension:countryCodeExt (VSDMISO3166Ergaenzung)
    - Organization.address.country.extension:anlage8 (VSDMISO3166Ergaenzung)
- Das Pflichtelement Coverage.status wird für VSDMCoverageGKV und VSDMCoveragePKV jetzt mit dem Festwert active belegt.
  Das Element musste auch vor dieser Änderung schon mit einem Wert belegt werden (FHIR Core-Vorgabe), allerdings war der zu verwendende Wert nicht definiert.
  ([issue 169](https://github.com/gematik/spec-VSDM2/issues/169))
- Der Verweis auf das CodeSystem /KBV_CS_SFHIR_KBV_DMP wurde auf die Draft-Version 1.07 aus kbv.all.st-rc aktualisiert.
  Damit ist es möglich, das bereits veröffentlichte (aber noch nicht in Kraft gesetzte) DMP 13 (Adipositas Kinder und Jugendliche) abzubilden.
  ([issue 181](https://github.com/gematik/spec-VSDM2/issues/181))
- Zur Behebung von Warnungen wurde der Slicing-Diskriminator in VSDMPayorOrganization.address.country.extension von pattern auf value geändert.
  Damit folgt das Slicing der Adresse in der Patient-Ressource.
  Diese Änderung hat keine Auswirkung auf die ausgelieferten Ressourcen.
  ([issue 97](https://github.com/gematik/spec-VSDM2/issues/97))
- Aktualisierung der Paketabhängigkeiten (keine inhaltlichen Auswirkungen)
  ([issue 189](https://github.com/gematik/spec-VSDM2/issues/189))
  - `kbv.basis` von Version 1.8.0 auf Version 1.9.0 
  - `kbv.all.st` von Version 1.41.0 auf Version 1.43.0 

### Abkündigung

(keine)

### Entfernung

- Das CodeSystem VSDMRuhenderLeistungsanspruchArtCS und das zugehörige ValueSet VSDMRuhenderLeistungsanspruchArtVS wurden durch die inhaltsgleichen Versionen aus dem deutschen Basisprofil ersetzt.
  ([issue 53](https://github.com/gematik/spec-VSDM2/issues/53))
- Das CodeSystem VSDMVersichertenartPKVCS und das zugehörige ValueSet VSDMVersichertenartPKVVS wurden durch die inhaltsgleichen Versionen aus dem deutschen Basisprofil ersetzt.
  ([issue 59](https://github.com/gematik/spec-VSDM2/issues/59))

### Fehlerbehebung

- Überflüssige Leerzeichen am Zeilenende der FSH-Dateien, die sich zum Teil auf die Ressourcen ausgewirkt haben, wurden entfernt.
  ([issue 166](https://github.com/gematik/spec-VSDM2/issues/166))
- Im CodeSystem VSDMVersichertenartPKVCS wurde die falsch angegebene Canonical URL (/ValueSet/ statt /CodeSystem/) korrigiert.
  ACHTUNG: Dadurch ändern sich die Inhalte der Nutzdaten-Ressourcen. Das ist allerdings unkritisch, da der PKV-Zweig des Profils noch nicht in Verwendung ist.
  ([issue 166](https://github.com/gematik/spec-VSDM2/issues/166))
- In VSDMHinweisPKV und VSDMCoveragePKV wurden kleinere Dokumentationsfehler behoben.
  ([issue 174](https://github.com/gematik/spec-VSDM2/issues/175))

### Security

(keine)