### PR TITLE
Paket kbv.basis durch kbv.basis.terminology ausgetauscht

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           #PATH_TO_QUALITY_CONTROL_RULES: qc/custom
           DOTNET_VALIDATION_ENABLED: true
           JAVA_VALIDATION_ENABLED: true
-          JAVA_VALIDATION_OPTIONS: -allow-example-urls true -advisor-file advisor.json -output-style compact -show-message-ids -jurisdiction de -tx n/a -ig de.basisprofil.r4#1.6.0 -ig de.gematik.terminology#1.0.9 -ig de.gematik.ti#1.3.1 -ig kbv.basis#1.9.0 -ig kbv.all.st#1.43.0 -ig kbv.all.st-rc#1.19.0 -ig kbv.ita.for#1.3.1
+          JAVA_VALIDATION_OPTIONS: -allow-example-urls true -advisor-file advisor.json -output-style compact -show-message-ids -jurisdiction de -tx n/a -ig de.basisprofil.r4#1.6.0 -ig de.gematik.terminology#1.0.9 -ig de.gematik.ti#1.3.1 -ig kbv.basis.terminology#1.9.0 -ig kbv.all.st#1.43.0 -ig kbv.all.st-rc#1.19.0 -ig kbv.ita.for#1.3.1
           SIMPLIFIER_USERNAME: ${{ secrets.SIMPLIFIER_USERNAME }}
           SIMPLIFIER_PASSWORD: ${{ secrets.SIMPLIFIER_PASSWORD }}
           SUSHI_ENABLED: true

--- a/CHANGELOG-FHIR.md
+++ b/CHANGELOG-FHIR.md
@@ -11,6 +11,10 @@ Historische Release Notes (vor Beginn dieser Aufzeichnung) wurden zum Teil unbea
 
 ### Änderung
 
+- Statt des Pakets `kbv.basis` wird jetzt das deutlich kleinere Paket `kbv.basis.terminology` verwendet.
+  Durch diese Änderung ergeben sich keine inhaltlichen Änderungen an den VSDM 2.0-Ressourcen.
+  ([issue 201](https://github.com/gematik/spec-VSDM2/issues/201))
+
 ### Abkündigung
 
 ### Entfernung

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "de.basisprofil.r4": "1.6.0",
     "de.gematik.terminology": "1.0.9",
     "de.gematik.ti": "1.3.1",
-    "kbv.basis": "1.9.0",
+    "kbv.basis.terminology": "1.9.0",
     "kbv.all.st": "1.43.0",
     "kbv.all.st-rc": "1.19.0",
     "kbv.ita.for": "1.3.1"

--- a/src/fhir/sushi-config.yaml
+++ b/src/fhir/sushi-config.yaml
@@ -15,7 +15,7 @@ dependencies:
   de.basisprofil.r4: 1.6.0
   de.gematik.terminology: 1.0.9
   de.gematik.ti: 1.3.1
-  kbv.basis: 1.9.0
+  kbv.basis.terminology: 1.9.0
   kbv.all.st: 1.43.0
   kbv.all.st-rc: 1.19.0 # für Vorgriff auf DMP 13 notwendig
   kbv.ita.for: 1.3.1


### PR DESCRIPTION
fixdes #201 
Checks sollten grün werden, sobald #200 eingebaut ist