### PR TITLE
Display-Text in VSDMTDSCodeIssueSeverity korrigiert

### DIFF
--- a/CHANGELOG-FHIR.md
+++ b/CHANGELOG-FHIR.md
@@ -17,6 +17,9 @@ Historische Release Notes (vor Beginn dieser Aufzeichnung) wurden zum Teil unbea
 
 ### Fehlerbehebung
 
+- In der ConceptMap VSDMTDSCodeIssueSeverity war dem Fehlercode #79014 noch der falsche Text zugeordnet.
+  ([issue 203](https://github.com/gematik/spec-VSDM2/issues/203))
+
 ### Security
 
 ## [1.1.0] - 2026-07-03

--- a/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeIssueSeverity.json
+++ b/src/fhir/fsh-generated/resources/ConceptMap-VSDMTDSCodeIssueSeverity.json
@@ -85,7 +85,7 @@
         },
         {
           "code": "79014",
-          "display": "Der Änderungsindikator '[etag_value]' kann nicht verarbeitet werden.",
+          "display": "Der erforderliche Änderungsindikator im Header If-None-Match fehlt.",
           "target": [
             {
               "code": "error",

--- a/src/fhir/input/fsh/mappings/VSDMTDSCodeIssueSeverity.fsh
+++ b/src/fhir/input/fsh/mappings/VSDMTDSCodeIssueSeverity.fsh
@@ -50,7 +50,7 @@ Usage: #definition
 
   * element[+]
     * code = #79014
-    * display = "Der Änderungsindikator '[etag_value]' kann nicht verarbeitet werden."
+    * display = "Der erforderliche Änderungsindikator im Header If-None-Match fehlt."
     * target[+]
       * code = #error
       * display = "Error"


### PR DESCRIPTION
fixes #203 
Checks sollten grün werden, sobald https://github.com/gematik/spec-VSDM2/pull/200 eingebaut ist